### PR TITLE
Add Home Assistant update runbook and update log

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         run: |
           pip install ansible-lint
 
+      - name: Install required Ansible collections
+        run: |
+          ansible-galaxy collection install -r ansible/requirements.yml
+
       - name: Run ansible-lint
         run: |
           ansible-lint ansible/

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Start with:
 - `how-to-enable-docker.md`
 - `ssh-key-rotation.md`
 - `host-recovery.md`
+- `home-assistant-updates.md`
 
 **If it is not written there, it is not supported.**
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,7 @@
+# Ansible configuration for this repository.
+#
+# Playbooks live in ansible/playbooks/ and roles in ansible/roles/, which is
+# not a layout Ansible discovers on its own. Without roles_path, both real
+# runs and ansible-lint fail with "the role '<name>' was not found".
+[defaults]
+roles_path = ansible/roles

--- a/ansible/group_vars/lab.yml
+++ b/ansible/group_vars/lab.yml
@@ -10,4 +10,3 @@ docker_users:
 
 # Example: More permissive settings for lab
 # vm_timezone: "America/New_York"  # Override default timezone if needed
-

--- a/ansible/group_vars/prod.yml
+++ b/ansible/group_vars/prod.yml
@@ -10,4 +10,3 @@ docker_users: []  # Empty by default - add users explicitly if needed
 # Example: Production-specific overrides
 # vm_timezone: "UTC"  # Explicit UTC for production
 # Additional production hardening can be added here
-

--- a/ansible/group_vars/proxmox_hosts.yml
+++ b/ansible/group_vars/proxmox_hosts.yml
@@ -80,4 +80,3 @@ admin_user_ssh_keys:
 
 # Node Exporter for monitoring (disabled by default; read-only metrics).
 node_exporter_enabled: false
-

--- a/ansible/group_vars/vms.yml
+++ b/ansible/group_vars/vms.yml
@@ -21,4 +21,3 @@ prometheus_enabled: false  # Set to true to enable Prometheus on monitoring VM
 
 # Grafana monitoring (optional)
 grafana_enabled: false  # Set to true to enable Grafana on monitoring VM
-

--- a/ansible/inventory.example.yml
+++ b/ansible/inventory.example.yml
@@ -37,4 +37,3 @@ all:
         ansible_user: "admin"
         ansible_port: 22
         ansible_ssh_common_args: '-o StrictHostKeyChecking=accept-new'
-

--- a/ansible/playbooks/host-audit.yml
+++ b/ansible/playbooks/host-audit.yml
@@ -74,13 +74,17 @@
       failed_when: false
 
     # Running services summary
-    - name: Get running services count
+    # The systemd module reports on one unit at a time; this audit wants the
+    # raw systemctl summary text verbatim for the report.
+    - name: Get running services count  # noqa: command-instead-of-module
       ansible.builtin.command:
         cmd: systemctl list-units --type=service --state=running --no-pager | wc -l
       register: running_services_count
       changed_when: false
 
-    - name: Get failed services
+    # The systemd module reports on one unit at a time; this audit wants the
+    # raw systemctl summary text verbatim for the report.
+    - name: Get failed services  # noqa: command-instead-of-module
       ansible.builtin.command:
         cmd: systemctl list-units --type=service --state=failed --no-pager || echo "No failed services"
       register: failed_services
@@ -92,61 +96,61 @@
       ansible.builtin.set_fact:
         host_audit_section: |
           ## Host: {{ inventory_hostname }}
-          
+
           ### System Information
           - **OS**: {{ ansible_distribution }} {{ ansible_distribution_version }}
           - **Kernel**: {{ ansible_kernel }}
           - **Architecture**: {{ ansible_architecture }}
           - **Uptime**: {{ ansible_uptime_seconds | int // 86400 }} days
-          
+
           ### Proxmox Version
           ```
           {{ pveversion_output.stdout | default('Not available') }}
           ```
-          
+
           ### CPU Information
           ```
           {{ cpu_info.stdout }}
           ```
-          
+
           ### Memory Summary
           ```
           {{ memory_info.stdout }}
           ```
-          
+
           ### Storage Devices
           **NVMe Devices:**
           ```
           {{ nvme_devices.stdout }}
           ```
-          
+
           **SSD/HDD Devices:**
           ```
           {{ ssd_devices.stdout }}
           ```
-          
+
           **ZFS Pools:**
           ```
           {{ zfs_pools.stdout }}
           ```
-          
+
           ### Network Interfaces
           ```
           {{ network_interfaces.stdout }}
           ```
-          
+
           **Network Bridges:**
           ```
           {{ network_bridges.stdout }}
           ```
-          
+
           ### Services
           - **Running services**: {{ running_services_count.stdout | trim }}
-          - **Failed services**: 
+          - **Failed services**:
           ```
           {{ failed_services.stdout }}
           ```
-          
+
           ---
 
   # Write all results to file in a single task
@@ -155,9 +159,9 @@
       ansible.builtin.set_fact:
         complete_audit_report: |
           # Proxmox Host Audit Report
-          
+
           Generated: {{ ansible_date_time.iso8601 }}
-          
+
           {% for host in groups['proxmox_hosts'] %}
           {{ hostvars[host]['host_audit_section'] | default('') }}
           {% endfor %}
@@ -171,4 +175,3 @@
         mode: '0644'
       delegate_to: localhost
       run_once: true
-

--- a/ansible/playbooks/vm-base.yml
+++ b/ansible/playbooks/vm-base.yml
@@ -49,7 +49,7 @@
 
     # Timezone configuration
     - name: Set timezone
-      ansible.builtin.timezone:
+      community.general.timezone:
         name: "{{ vm_timezone }}"
 
     # Basic SSH safety (LAN-friendly, not over-hardened)

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,6 @@
+---
+# Collections required by the playbooks and roles in this repository.
+# Install with: ansible-galaxy collection install -r ansible/requirements.yml
+collections:
+  - name: ansible.posix       # authorized_key, sysctl
+  - name: community.general   # timezone

--- a/ansible/roles/admin_user/tasks/main.yml
+++ b/ansible/roles/admin_user/tasks/main.yml
@@ -42,4 +42,3 @@
     content: "{{ admin_user_name }} ALL=(ALL) NOPASSWD:ALL\n"
     validate: "visudo -cf %s"
   when: admin_user_enabled | bool
-

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -69,4 +69,3 @@
 - name: Display Docker version
   ansible.builtin.debug:
     msg: "Docker installed: {{ docker_version.stdout | default('Unable to determine version') }}"
-

--- a/ansible/roles/grafana/files/dashboards.yml
+++ b/ansible/roles/grafana/files/dashboards.yml
@@ -11,4 +11,3 @@ providers:
     options:
       path: /etc/grafana/provisioning/dashboards
       foldersFromFilesStructure: false
-

--- a/ansible/roles/grafana/handlers/main.yml
+++ b/ansible/roles/grafana/handlers/main.yml
@@ -5,4 +5,3 @@
   ansible.builtin.service:
     name: grafana-server
     state: restarted
-

--- a/ansible/roles/grafana/tasks/main.yml
+++ b/ansible/roles/grafana/tasks/main.yml
@@ -84,7 +84,7 @@
     paths: "{{ playbook_dir }}/../../../monitoring/grafana/dashboards"
     patterns: "*.json"
     file_type: file
-  register: dashboard_files
+  register: grafana_dashboard_files
 
 - name: Deploy dashboard JSON files
   ansible.builtin.copy:
@@ -93,9 +93,9 @@
     owner: root
     group: root
     mode: '0644'
-  loop: "{{ dashboard_files.files }}"
+  loop: "{{ grafana_dashboard_files.files }}"
   notify: Restart grafana
-  when: dashboard_files.matched > 0
+  when: grafana_dashboard_files.matched > 0
 
 - name: Ensure Grafana service is enabled and running
   ansible.builtin.service:
@@ -103,7 +103,9 @@
     state: started
     enabled: true
 
-- name: Verify Grafana is listening on port 3000
+# A post-install verification, not a state change: it must run inline so a
+# failed install fails the play here, rather than at the end with the handlers.
+- name: Verify Grafana is listening on port 3000  # noqa: no-handler
   ansible.builtin.wait_for:
     port: 3000
     host: localhost
@@ -111,4 +113,3 @@
     timeout: 10
   delegate_to: localhost
   when: grafana_installed.changed
-

--- a/ansible/roles/node_exporter/handlers/main.yml
+++ b/ansible/roles/node_exporter/handlers/main.yml
@@ -5,4 +5,3 @@
   ansible.builtin.service:
     name: prometheus-node-exporter
     state: restarted
-

--- a/ansible/roles/node_exporter/tasks/main.yml
+++ b/ansible/roles/node_exporter/tasks/main.yml
@@ -17,7 +17,9 @@
     state: started
     enabled: true
 
-- name: Verify node_exporter is listening on port 9100
+# A post-install verification, not a state change: it must run inline so a
+# failed install fails the play here, rather than at the end with the handlers.
+- name: Verify node_exporter is listening on port 9100  # noqa: no-handler
   ansible.builtin.wait_for:
     port: 9100
     host: localhost
@@ -25,4 +27,3 @@
     timeout: 10
   delegate_to: localhost
   when: node_exporter_installed.changed
-

--- a/ansible/roles/prometheus/handlers/main.yml
+++ b/ansible/roles/prometheus/handlers/main.yml
@@ -5,4 +5,3 @@
   ansible.builtin.service:
     name: prometheus
     state: restarted
-

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -35,7 +35,9 @@
     state: started
     enabled: true
 
-- name: Verify Prometheus is listening on port 9090
+# A post-install verification, not a state change: it must run inline so a
+# failed install fails the play here, rather than at the end with the handlers.
+- name: Verify Prometheus is listening on port 9090  # noqa: no-handler
   ansible.builtin.wait_for:
     port: 9090
     host: localhost
@@ -43,4 +45,3 @@
     timeout: 10
   delegate_to: localhost
   when: prometheus_installed.changed
-

--- a/ansible/roles/ssh_keys/tasks/main.yml
+++ b/ansible/roles/ssh_keys/tasks/main.yml
@@ -35,4 +35,3 @@
     mode: "0600"
     content: "{{ (ssh_allowed_keys | join('\n')) ~ '\n' }}"
   when: ssh_keys_enforce | bool
-

--- a/docs/operations/home-assistant-update-log.md
+++ b/docs/operations/home-assistant-update-log.md
@@ -49,5 +49,13 @@ Notification: *"🔧 Garaaž HA — uuendusi ootel — 11 uuendust"*.
 - Devices #10 and #11 still carry factory hostnames. Identify and rename them
   in Home Assistant before flashing.
 
+**Planned sessions:** not one sitting. Suggested split — session A: #1–#2
+(Core + OS, the long ones, budget a half-day for the recorder migration alone);
+session B: #3–#6 (add-ons + Better Thermostat); session C: #7–#11 (Shelly
+firmware, on site, one device at a time). Splitting makes it obvious which
+change caused a problem.
+
 **Notes:** Physical access to the garage is required for the Shelly firmware
-updates (#7–#11). Do not start that step remotely.
+updates (#7–#11). Do not start that step remotely. Allow up to 24 hours after
+the last change before calling the batch done — battery Zigbee devices only
+report when they next wake.

--- a/docs/operations/home-assistant-update-log.md
+++ b/docs/operations/home-assistant-update-log.md
@@ -1,61 +1,61 @@
-# Home Assistant Update Log — Garaaž HA
+# Home Assistanti uuenduste logi — Garaaž HA
 
-One entry per update session. Procedure:
+Üks kanne uuendussessiooni kohta. Protseduur:
 `docs/operations/home-assistant-updates.md`.
 
-Record what was applied, what was held back and why, and anything that broke.
-An update that is not logged did not happen.
+Pane kirja, mis sai paigaldatud, mis jäi tagasi hoituks ja miks, ning mis läks
+katki. Uuendust, mida ei ole logitud, ei ole toimunud.
 
-Entry template:
+Kande mall:
 
 ```
-## YYYY-MM-DD
+## AAAA-KK-PP
 
-**Pending:** <count> — <list>
-**Applied:** <list, in order>
-**Held:** <list + reason>
-**Notes:** <what broke, what was verified, snapshot deleted y/n>
+**Ootel:** <arv> — <loend>
+**Paigaldatud:** <loend, järjekorras>
+**Tagasi hoitud:** <loend + põhjus>
+**Märkused:** <mis läks katki, mis sai kontrollitud, snapshot kustutatud jah/ei>
 ```
 
 ---
 
-## 2026-08-31 — pending, not yet applied
+## 2026-08-31 — ootel, veel paigaldamata
 
-Notification: *"🔧 Garaaž HA — uuendusi ootel — 11 uuendust"*.
+Teavitus: *„🔧 Garaaž HA — uuendusi ootel — 11 uuendust"*.
 
-**Pending (11):**
+**Ootel (11):**
 
-| # | Update | Layer | Risk | Order |
+| # | Uuendus | Kiht | Risk | Järjekord |
 | --- | --- | --- | --- | --- |
-| 1 | Home Assistant Core | Core | High — breaking changes, custom integrations | Step 1 |
-| 2 | Home Assistant Operating System | OS | Medium — full reboot, USB passthrough | Step 2 |
-| 3 | Zigbee2MQTT | Add-on | High — config migrations, Zigbee network | Step 3 |
-| 4 | Grafana | Add-on | Low | Step 3 |
-| 5 | Home Assistant MCP Server | Add-on | Low — check Core compatibility first | Step 3 |
-| 6 | Better Thermostat | HACS custom integration | High — breaks on Core upgrades | Step 4 (check before Step 1) |
-| 7 | `K1 Max – kapi vent` (Shelly 1 Mini) | Device firmware | Medium | Step 5 |
-| 8 | `K1 Max – printeri toide` (Shelly 1PM) | Device firmware | **High — printer mains power** | Step 5, printer idle only |
-| 9 | `Kapi all lambid` (Shelly 1 Mini) | Device firmware | Medium | Step 5 |
-| 10 | `shelly1minig3-54320468c06c` | Device firmware | Unknown load | Step 5, identify first |
-| 11 | `shelly1minig3-dcda0ce25a78` | Device firmware | Unknown load | Step 5, identify first |
+| 1 | Home Assistant Core | Core | Kõrge — murdvad muudatused, kohandatud integratsioonid | Samm 1 |
+| 2 | Home Assistant Operating System | OS | Keskmine — täielik alglaadimine, USB läbiandmine | Samm 2 |
+| 3 | Zigbee2MQTT | Lisand | Kõrge — konfiguratsiooni migratsioonid, Zigbee võrk | Samm 3 |
+| 4 | Grafana | Lisand | Madal | Samm 3 |
+| 5 | Home Assistant MCP Server | Lisand | Madal — kontrolli enne Core'iga ühilduvust | Samm 3 |
+| 6 | Better Thermostat | HACS kohandatud integratsioon | Kõrge — puruneb Core'i uuendustel | Samm 4 (kontrolli enne sammu 1) |
+| 7 | `K1 Max – kapi vent` (Shelly 1 Mini) | Seadme püsivara | Keskmine | Samm 5 |
+| 8 | `K1 Max – printeri toide` (Shelly 1PM) | Seadme püsivara | **Kõrge — printeri võrgutoide** | Samm 5, ainult jõude printeriga |
+| 9 | `Kapi all lambid` (Shelly 1 Mini) | Seadme püsivara | Keskmine | Samm 5 |
+| 10 | `shelly1minig3-54320468c06c` | Seadme püsivara | Tundmatu koormus | Samm 5, tuvasta enne |
+| 11 | `shelly1minig3-dcda0ce25a78` | Seadme püsivara | Tundmatu koormus | Samm 5, tuvasta enne |
 
-**Applied:** none yet.
+**Paigaldatud:** veel mitte ühtegi.
 
-**Blockers / prerequisites:**
+**Takistused / eeltingimused:**
 
-- Backup + Proxmox snapshot not yet taken (Step 0).
-- Better Thermostat compatibility with the target Core version not yet
-  verified. Verify before applying #1.
-- Devices #10 and #11 still carry factory hostnames. Identify and rename them
-  in Home Assistant before flashing.
+- Varukoopia ja Proxmoxi snapshot tegemata (samm 0).
+- Better Thermostati ühilduvus sihtversiooniga Core'ist kontrollimata.
+  Kontrolli enne #1 paigaldamist.
+- Seadmed #10 ja #11 kannavad endiselt tehase hostinimesid. Tuvasta ja nimeta
+  need Home Assistantis, enne kui neid välgud.
 
-**Planned sessions:** not one sitting. Suggested split — session A: #1–#2
-(Core + OS, the long ones, budget a half-day for the recorder migration alone);
-session B: #3–#6 (add-ons + Better Thermostat); session C: #7–#11 (Shelly
-firmware, on site, one device at a time). Splitting makes it obvious which
-change caused a problem.
+**Planeeritud sessioonid:** mitte ühe korraga. Soovitatav jaotus — sessioon A:
+#1–#2 (Core + OS, pikad; ainuüksi recorderi migratsiooniks arvesta pool päeva);
+sessioon B: #3–#6 (lisandid + Better Thermostat); sessioon C: #7–#11 (Shelly
+püsivara, kohapeal, üks seade korraga). Jaotamine teeb selgeks, milline muudatus
+probleemi tekitas.
 
-**Notes:** Physical access to the garage is required for the Shelly firmware
-updates (#7–#11). Do not start that step remotely. Allow up to 24 hours after
-the last change before calling the batch done — battery Zigbee devices only
-report when they next wake.
+**Märkused:** Shelly püsivara uuendused (#7–#11) nõuavad füüsilist ligipääsu
+garaažile. Ära alusta seda sammu eemalt. Arvesta pärast viimast muudatust kuni
+24 tundi, enne kui partii valmiks loed — patareitoitel Zigbee seadmed
+raporteerivad alles siis, kui nad järgmine kord ärkavad.

--- a/docs/operations/home-assistant-update-log.md
+++ b/docs/operations/home-assistant-update-log.md
@@ -1,0 +1,53 @@
+# Home Assistant Update Log — Garaaž HA
+
+One entry per update session. Procedure:
+`docs/operations/home-assistant-updates.md`.
+
+Record what was applied, what was held back and why, and anything that broke.
+An update that is not logged did not happen.
+
+Entry template:
+
+```
+## YYYY-MM-DD
+
+**Pending:** <count> — <list>
+**Applied:** <list, in order>
+**Held:** <list + reason>
+**Notes:** <what broke, what was verified, snapshot deleted y/n>
+```
+
+---
+
+## 2026-08-31 — pending, not yet applied
+
+Notification: *"🔧 Garaaž HA — uuendusi ootel — 11 uuendust"*.
+
+**Pending (11):**
+
+| # | Update | Layer | Risk | Order |
+| --- | --- | --- | --- | --- |
+| 1 | Home Assistant Core | Core | High — breaking changes, custom integrations | Step 1 |
+| 2 | Home Assistant Operating System | OS | Medium — full reboot, USB passthrough | Step 2 |
+| 3 | Zigbee2MQTT | Add-on | High — config migrations, Zigbee network | Step 3 |
+| 4 | Grafana | Add-on | Low | Step 3 |
+| 5 | Home Assistant MCP Server | Add-on | Low — check Core compatibility first | Step 3 |
+| 6 | Better Thermostat | HACS custom integration | High — breaks on Core upgrades | Step 4 (check before Step 1) |
+| 7 | `K1 Max – kapi vent` (Shelly 1 Mini) | Device firmware | Medium | Step 5 |
+| 8 | `K1 Max – printeri toide` (Shelly 1PM) | Device firmware | **High — printer mains power** | Step 5, printer idle only |
+| 9 | `Kapi all lambid` (Shelly 1 Mini) | Device firmware | Medium | Step 5 |
+| 10 | `shelly1minig3-54320468c06c` | Device firmware | Unknown load | Step 5, identify first |
+| 11 | `shelly1minig3-dcda0ce25a78` | Device firmware | Unknown load | Step 5, identify first |
+
+**Applied:** none yet.
+
+**Blockers / prerequisites:**
+
+- Backup + Proxmox snapshot not yet taken (Step 0).
+- Better Thermostat compatibility with the target Core version not yet
+  verified. Verify before applying #1.
+- Devices #10 and #11 still carry factory hostnames. Identify and rename them
+  in Home Assistant before flashing.
+
+**Notes:** Physical access to the garage is required for the Shelly firmware
+updates (#7–#11). Do not start that step remotely.

--- a/docs/operations/home-assistant-updates.md
+++ b/docs/operations/home-assistant-updates.md
@@ -21,8 +21,38 @@ before the first one starts.
   touched during a print job.
 - **Read release notes before Core and Zigbee2MQTT.** Both ship breaking
   changes in normal releases.
+- **Never start an update you cannot wait out.** Every step below finishes on
+  its own schedule, not yours. See *Time budget*.
 - **One update session, one log entry.** See
   `docs/operations/home-assistant-update-log.md`.
+
+## Time budget
+
+**Plan a half-day window, not an hour.** These updates are slow, and most of
+the elapsed time is waiting, not clicking. Rushing is what turns a routine
+update into an outage: the common failure is an operator who decides something
+is stuck, restarts or power-cycles mid-operation, and breaks it for real.
+
+| Step | Realistic time | What drives it |
+| --- | --- | --- |
+| 0 – Backup + snapshot | 10–30 min | Backup size; copying it off the VM |
+| 1 – Core | 10–20 min, **plus DB migration** | See below — migration can run for hours |
+| 2 – OS | 15–30 min | Download, reboot, slower first boot |
+| 3 – Add-ons | 5–15 min each | Z2M network settling is extra, see below |
+| 4 – Better Thermostat | 5 min, plus a heating cycle | Calibration re-establishes over time |
+| 5 – Shelly firmware | 5–10 min per device | Reboot and Wi-Fi reconnect per device |
+
+Full settling — every device reporting normally again — can take **up to 24
+hours** after the last change. Do not judge the result on the first ten
+minutes.
+
+**Splitting the batch across several days is normal and preferred.** There is
+no requirement to clear all pending updates in one sitting. Core and OS in one
+session, add-ons in another, device firmware in a third is a perfectly good
+plan, and it makes it obvious which change caused a problem.
+
+Do not start on an evening when the garage is needed the next morning, and do
+not start remotely.
 
 ## Step 0 – Rollback path (mandatory)
 
@@ -61,15 +91,29 @@ means **Better Thermostat** (HACS) and the **Home Assistant MCP Server**:
 confirm the version you are moving to supports the target Core release. If it
 does not, update the integration first, or hold Core back.
 
+**The recorder database migration is the slow part.** Some Core releases
+change the recorder schema and migrate the database *after* HA has already
+started. During that migration HA is reachable but sluggish, and history and
+the logbook are incomplete. On a long-lived database this runs for anything
+from a few minutes to several hours. **Do not restart HA, and do not reboot the
+VM, while it is running** — an interrupted migration is how the database gets
+corrupted. Watch the log for the migration to report finished; only then judge
+whether the update worked.
+
 Verify: HA restarts, Settings → System → Repairs is clean, the garage
-automations still show as available (no `unavailable` entities).
+automations still show as available (no `unavailable` entities). Give entities
+a few minutes to repopulate before treating an `unavailable` one as broken.
 
 ## Step 2 – Home Assistant Operating System
 
 Settings → System → Updates → *Home Assistant Operating System* → Update.
 
-This reboots the whole appliance. Expect the VM to be unreachable for a few
-minutes. Do not run it remotely unless you can reach the Proxmox console.
+This reboots the whole appliance. Expect the VM to be unreachable for several
+minutes — the download runs first, then the reboot, and the first boot on a new
+OS version is slower than usual. **Do not force-stop the VM from Proxmox
+because the UI has not come back yet**; give it a good 15 minutes before
+treating it as hung. Do not run this step remotely unless you can reach the
+Proxmox console.
 
 Verify: VM boots, HA UI returns, Settings → System → Hardware still lists the
 Zigbee coordinator (a USB passthrough that silently drops after a reboot is the
@@ -81,8 +125,15 @@ Update one at a time, verifying between each:
 
 1. **Zigbee2MQTT** — the highest-risk add-on. Confirm `coordinator_backup.json`
    is current (Step 0), read the Z2M release notes for configuration migrations,
-   then update. Verify: add-on starts, all Zigbee devices report in, and a
-   round-trip works (toggle one device from HA and see the state come back).
+   then update. Verify: add-on starts, and a round-trip works (toggle one
+   mains-powered device from HA and see the state come back).
+
+   **Do not expect the whole Zigbee network back immediately.** Mains-powered
+   routers rejoin within minutes. Battery devices only report when they next
+   wake up, which can be hours — a battery sensor still showing as unavailable
+   the same evening is normal and is not evidence that the update failed. Do
+   not re-pair anything on day one; re-pairing a device that was going to come
+   back on its own only makes the mesh worse.
 2. **Grafana** — low risk. Verify: dashboards render and the Prometheus data
    source is still connected (see `monitoring/grafana/README.md`).
 3. **Home Assistant MCP Server** — verify the MCP client can still list tools
@@ -91,9 +142,13 @@ Update one at a time, verifying between each:
 ## Step 4 – Custom integrations (HACS)
 
 **Better Thermostat**: update via HACS, then restart Home Assistant. Verify the
-climate entities are back and are not stuck in `unavailable`; Better Thermostat
-holds calibration state that is re-established on restart, so check the target
-temperature actually applies to the valve.
+climate entities are back and are not stuck in `unavailable`.
+
+Better Thermostat holds calibration state that is re-established after a
+restart, and that takes a full heating cycle — the valve position looking wrong
+in the first minutes after the restart is expected, not a fault. Check that the
+target temperature actually reaches the valve, then leave it alone for a cycle
+before concluding anything.
 
 ## Step 5 – Shelly device firmware (last, one at a time)
 
@@ -103,6 +158,12 @@ cycled by hand.
 
 For each device: check what it controls, confirm the load is idle, update,
 wait for it to come back, verify it responds from HA. Then move to the next.
+
+**Wait out each device before starting the next one.** A Shelly reboots and
+reconnects to Wi-Fi after flashing, which takes a few minutes; a Gen3 doing a
+two-stage update takes longer and can look dead in between. **Never cut power
+to a Shelly that is mid-update** — that is the one reliable way to brick it.
+Budget 5–10 minutes per device and do not batch them.
 
 Current garage devices:
 
@@ -125,6 +186,22 @@ load is how the printer loses power mid-print.
 2. Check Settings → System → Repairs and the error log.
 3. Delete the Proxmox snapshot from Step 0.
 4. Add an entry to `docs/operations/home-assistant-update-log.md`.
+
+## Slow is not broken
+
+Most "the update broke everything" reports are an operator intervening too
+early. Before acting, check whether what you are seeing is on this list:
+
+| What you see | Normal wait before it is a problem |
+| --- | --- |
+| HA sluggish, history gaps after a Core update | Until the recorder migration finishes — minutes to hours. Do not restart |
+| VM unreachable after the OS update | ~15 min, including download and a slow first boot |
+| Entities `unavailable` right after a restart | A few minutes while they repopulate |
+| Battery Zigbee devices missing after a Z2M update | Until they next wake — often hours. Do not re-pair |
+| Valve position looks wrong after Better Thermostat | One full heating cycle |
+| A Shelly offline right after flashing | Several minutes. Never cut its power meanwhile |
+
+If it is still wrong after the wait, then it is a fault — see below.
 
 ## If it breaks
 

--- a/docs/operations/home-assistant-updates.md
+++ b/docs/operations/home-assistant-updates.md
@@ -1,0 +1,137 @@
+# How to Update the Garage Home Assistant Stack
+
+Runbook for applying updates to the **Garaaž HA** instance (Home Assistant OS
+running as a VM on Proxmox) and to the Zigbee/Wi-Fi devices it manages.
+
+Home Assistant announces pending updates as a single notification, e.g.:
+
+> 🔧 Garaaž HA — uuendusi ootel
+> 11 uuendust: Home Assistant Core, Home Assistant Operating System, Zigbee2MQTT, …
+
+That notification is **not** an instruction to press "Update all". Updates are
+applied in a fixed order, one layer at a time, with a rollback path in place
+before the first one starts.
+
+## Rules
+
+- **Never bulk-update.** One layer at a time, verify, then continue.
+- **Never update device firmware you cannot physically reach.** A failed Shelly
+  flash can require a power cycle or a factory reset at the device.
+- **Never update while the load is in use.** The printer power switch is not
+  touched during a print job.
+- **Read release notes before Core and Zigbee2MQTT.** Both ship breaking
+  changes in normal releases.
+- **One update session, one log entry.** See
+  `docs/operations/home-assistant-update-log.md`.
+
+## Step 0 – Rollback path (mandatory)
+
+Do this before touching anything.
+
+1. **Home Assistant backup**: Settings → System → Backups → *Create backup*
+   (full). Confirm it completed and note the size.
+2. **Copy the backup off the VM**. A backup that only exists inside the VM you
+   are about to break is not a backup.
+3. **Proxmox snapshot** of the HA VM, taken while the VM is running:
+
+   ```bash
+   # on the Proxmox host, <vmid> = the Home Assistant VM
+   qm snapshot <vmid> pre-ha-update-$(date +%Y%m%d) --description "before HA update batch"
+   ```
+
+4. **Zigbee2MQTT coordinator backup**: Z2M writes `coordinator_backup.json`
+   into its data directory on every start. Confirm it exists and is current
+   before updating Z2M.
+
+Rollback = restore the Proxmox snapshot (whole appliance) or restore the HA
+backup (configuration only). Delete the snapshot once the stack is verified
+healthy — snapshots left on disk grow and violate `docs/storage-policy.md`.
+
+## Step 1 – Home Assistant Core
+
+Read the release notes for **every** version between the installed one and the
+target, specifically the "Breaking changes" section.
+
+Settings → System → Updates → *Home Assistant Core* → Update.
+Leave "Create backup before updating" enabled.
+
+**Before updating Core, check custom integrations.** Custom components are the
+usual cause of a broken start after a Core upgrade. For this instance that
+means **Better Thermostat** (HACS) and the **Home Assistant MCP Server**:
+confirm the version you are moving to supports the target Core release. If it
+does not, update the integration first, or hold Core back.
+
+Verify: HA restarts, Settings → System → Repairs is clean, the garage
+automations still show as available (no `unavailable` entities).
+
+## Step 2 – Home Assistant Operating System
+
+Settings → System → Updates → *Home Assistant Operating System* → Update.
+
+This reboots the whole appliance. Expect the VM to be unreachable for a few
+minutes. Do not run it remotely unless you can reach the Proxmox console.
+
+Verify: VM boots, HA UI returns, Settings → System → Hardware still lists the
+Zigbee coordinator (a USB passthrough that silently drops after a reboot is the
+failure mode to watch for here).
+
+## Step 3 – Add-ons
+
+Update one at a time, verifying between each:
+
+1. **Zigbee2MQTT** — the highest-risk add-on. Confirm `coordinator_backup.json`
+   is current (Step 0), read the Z2M release notes for configuration migrations,
+   then update. Verify: add-on starts, all Zigbee devices report in, and a
+   round-trip works (toggle one device from HA and see the state come back).
+2. **Grafana** — low risk. Verify: dashboards render and the Prometheus data
+   source is still connected (see `monitoring/grafana/README.md`).
+3. **Home Assistant MCP Server** — verify the MCP client can still list tools
+   after the restart.
+
+## Step 4 – Custom integrations (HACS)
+
+**Better Thermostat**: update via HACS, then restart Home Assistant. Verify the
+climate entities are back and are not stuck in `unavailable`; Better Thermostat
+holds calibration state that is re-established on restart, so check the target
+temperature actually applies to the valve.
+
+## Step 5 – Shelly device firmware (last, one at a time)
+
+Device firmware is updated **after** the platform is confirmed healthy, never
+in the same pass. A failed flash leaves the device offline until it is power
+cycled by hand.
+
+For each device: check what it controls, confirm the load is idle, update,
+wait for it to come back, verify it responds from HA. Then move to the next.
+
+Current garage devices:
+
+| Device | Model | Controls | Precondition |
+| --- | --- | --- | --- |
+| `K1 Max – kapi vent` | Shelly 1 Mini | Cabinet fan | Printer idle and cool |
+| `K1 Max – printeri toide` | Shelly 1PM | Printer mains power | **No print running.** Cutting power mid-print destroys the job |
+| `Kapi all lambid` | Shelly 1 Mini | Under-cabinet lights | Nobody working in the cabinet |
+| `shelly1minig3-54320468c06c` | Shelly 1 Mini Gen3 | Unidentified — **identify before updating** | Load known and idle |
+| `shelly1minig3-dcda0ce25a78` | Shelly 1 Mini Gen3 | Unidentified — **identify before updating** | Load known and idle |
+
+Two devices still carry factory hostnames. Name them in Home Assistant before
+updating them — an unnamed relay is an unknown load, and updating an unknown
+load is how the printer loses power mid-print.
+
+## Step 6 – Close out
+
+1. Confirm Settings → System → Updates is empty (or that anything left is
+   deliberately held, with the reason logged).
+2. Check Settings → System → Repairs and the error log.
+3. Delete the Proxmox snapshot from Step 0.
+4. Add an entry to `docs/operations/home-assistant-update-log.md`.
+
+## If it breaks
+
+| Symptom | Action |
+| --- | --- |
+| HA does not start after Core update | Restore the HA backup, or roll back Core from the CLI: `ha core update --version <previous>` |
+| Whole appliance unreachable after OS update | Proxmox console; if unrecoverable, restore the snapshot from Step 0 |
+| Zigbee devices all gone after Z2M update | Restore `coordinator_backup.json` and pin the previous Z2M version |
+| Zigbee coordinator missing after reboot | Check USB passthrough on the VM in Proxmox before re-pairing anything |
+| Shelly offline after firmware update | Power cycle at the breaker; if still dead, factory reset and re-adopt |

--- a/docs/operations/home-assistant-updates.md
+++ b/docs/operations/home-assistant-updates.md
@@ -1,214 +1,218 @@
-# How to Update the Garage Home Assistant Stack
+# Garaaži Home Assistanti uuendamine
 
-Runbook for applying updates to the **Garaaž HA** instance (Home Assistant OS
-running as a VM on Proxmox) and to the Zigbee/Wi-Fi devices it manages.
+Tööjuhend **Garaaž HA** instantsi (Proxmoxis VM-ina jooksev Home Assistant OS)
+ja selle hallatavate Zigbee/Wi-Fi seadmete uuendamiseks.
 
-Home Assistant announces pending updates as a single notification, e.g.:
+Home Assistant teatab ootel uuendustest ühe teavitusega, näiteks:
 
 > 🔧 Garaaž HA — uuendusi ootel
 > 11 uuendust: Home Assistant Core, Home Assistant Operating System, Zigbee2MQTT, …
 
-That notification is **not** an instruction to press "Update all". Updates are
-applied in a fixed order, one layer at a time, with a rollback path in place
-before the first one starts.
+See teavitus **ei ole** korraldus vajutada „Uuenda kõik". Uuendused paigaldatakse
+kindlas järjekorras, üks kiht korraga, ja taastetee peab olema paigas enne, kui
+esimenegi neist algab.
 
-## Rules
+## Reeglid
 
-- **Never bulk-update.** One layer at a time, verify, then continue.
-- **Never update device firmware you cannot physically reach.** A failed Shelly
-  flash can require a power cycle or a factory reset at the device.
-- **Never update while the load is in use.** The printer power switch is not
-  touched during a print job.
-- **Read release notes before Core and Zigbee2MQTT.** Both ship breaking
-  changes in normal releases.
-- **Never start an update you cannot wait out.** Every step below finishes on
-  its own schedule, not yours. See *Time budget*.
-- **One update session, one log entry.** See
+- **Mitte kunagi ei uuenda kõike korraga.** Üks kiht korraga, kontrolli, siis edasi.
+- **Ära uuenda püsivara seadmel, milleni sa füüsiliselt ei ulatu.** Ebaõnnestunud
+  Shelly välkimine võib nõuda voolu väljalülitamist või tehaseseadete taastamist
+  seadme juures kohapeal.
+- **Ära uuenda, kui koormus on kasutuses.** Printeri toitelülitit ei puututa
+  printimise ajal.
+- **Loe väljalaskemärkmeid enne Core'i ja Zigbee2MQTT-d.** Mõlemad toovad
+  tavaväljalasetes murdvaid muudatusi.
+- **Ära alusta uuendust, mida sa ei suuda lõpuni oodata.** Iga alljärgnev samm
+  lõpeb omas tempos, mitte sinu omas. Vaata *Ajaeelarve*.
+- **Üks uuendussessioon, üks logikanne.** Vaata
   `docs/operations/home-assistant-update-log.md`.
 
-## Time budget
+## Ajaeelarve
 
-**Plan a half-day window, not an hour.** These updates are slow, and most of
-the elapsed time is waiting, not clicking. Rushing is what turns a routine
-update into an outage: the common failure is an operator who decides something
-is stuck, restarts or power-cycles mid-operation, and breaks it for real.
+**Planeeri pool päeva, mitte tund.** Need uuendused on aeglased ja suurem osa
+kuluvast ajast on ootamine, mitte klikkimine. Kiirustamine on see, mis muudab
+rutiinse uuenduse rikkeks: tüüpiline ebaõnnestumine on operaator, kes otsustab,
+et miski on kinni jooksnud, teeb keset operatsiooni restardi või võtab voolu ära
+— ja lõhub asja päriselt.
 
-| Step | Realistic time | What drives it |
+| Samm | Reaalne aeg | Mis seda määrab |
 | --- | --- | --- |
-| 0 – Backup + snapshot | 10–30 min | Backup size; copying it off the VM |
-| 1 – Core | 10–20 min, **plus DB migration** | See below — migration can run for hours |
-| 2 – OS | 15–30 min | Download, reboot, slower first boot |
-| 3 – Add-ons | 5–15 min each | Z2M network settling is extra, see below |
-| 4 – Better Thermostat | 5 min, plus a heating cycle | Calibration re-establishes over time |
-| 5 – Shelly firmware | 5–10 min per device | Reboot and Wi-Fi reconnect per device |
+| 0 – Varukoopia + snapshot | 10–30 min | Varukoopia suurus, väljakopeerimine VM-ist |
+| 1 – Core | 10–20 min, **pluss AB migratsioon** | Vaata allpool — migratsioon võib kesta tunde |
+| 2 – OS | 15–30 min | Allalaadimine, alglaadimine, aeglasem esimene boot |
+| 3 – Lisandid | 5–15 min igaüks | Z2M võrgu settimine tuleb lisaks, vaata allpool |
+| 4 – Better Thermostat | 5 min, pluss üks küttetsükkel | Kalibratsioon taastub tasapisi |
+| 5 – Shelly püsivara | 5–10 min seadme kohta | Alglaadimine ja Wi-Fi taasühendus iga seadme kohta |
 
-Full settling — every device reporting normally again — can take **up to 24
-hours** after the last change. Do not judge the result on the first ten
-minutes.
+Täielik settimine — kõik seadmed jälle normaalselt raporteerimas — võib pärast
+viimast muudatust võtta **kuni 24 tundi**. Ära hinda tulemust esimese kümne
+minuti järgi.
 
-**Splitting the batch across several days is normal and preferred.** There is
-no requirement to clear all pending updates in one sitting. Core and OS in one
-session, add-ons in another, device firmware in a third is a perfectly good
-plan, and it makes it obvious which change caused a problem.
+**Partii jagamine mitmele päevale on normaalne ja eelistatud.** Ei ole nõuet
+kõiki ootel uuendusi ühe korraga ära teha. Core ja OS ühes sessioonis, lisandid
+teises, seadmete püsivara kolmandas on täiesti korralik plaan — ja nii on ka
+selgelt näha, milline muudatus probleemi tekitas.
 
-Do not start on an evening when the garage is needed the next morning, and do
-not start remotely.
+Ära alusta õhtul, kui garaaži on järgmisel hommikul vaja, ja ära alusta
+eemalt.
 
-## Step 0 – Rollback path (mandatory)
+## Samm 0 – Taastetee (kohustuslik)
 
-Do this before touching anything.
+Tee see ära, enne kui midagi puutud.
 
-1. **Home Assistant backup**: Settings → System → Backups → *Create backup*
-   (full). Confirm it completed and note the size.
-2. **Copy the backup off the VM**. A backup that only exists inside the VM you
-   are about to break is not a backup.
-3. **Proxmox snapshot** of the HA VM, taken while the VM is running:
+1. **Home Assistanti varukoopia**: Seaded → Süsteem → Varukoopiad →
+   *Loo varukoopia* (täielik). Veendu, et see lõppes edukalt, ja pane suurus kirja.
+2. **Kopeeri varukoopia VM-ist välja.** Varukoopia, mis on olemas ainult selle
+   VM-i sees, mida sa kohe lõhkuma hakkad, ei ole varukoopia.
+3. **Proxmoxi hetktõmmis (snapshot)** HA VM-ist, tehtud töötava VM-i pealt:
 
    ```bash
-   # on the Proxmox host, <vmid> = the Home Assistant VM
-   qm snapshot <vmid> pre-ha-update-$(date +%Y%m%d) --description "before HA update batch"
+   # Proxmoxi hostil, <vmid> = Home Assistanti VM
+   qm snapshot <vmid> pre-ha-update-$(date +%Y%m%d) --description "enne HA uuenduste partiid"
    ```
 
-4. **Zigbee2MQTT coordinator backup**: Z2M writes `coordinator_backup.json`
-   into its data directory on every start. Confirm it exists and is current
-   before updating Z2M.
+4. **Zigbee2MQTT koordinaatori varukoopia**: Z2M kirjutab igal käivitusel oma
+   andmekataloogi faili `coordinator_backup.json`. Veendu enne Z2M uuendamist,
+   et see on olemas ja värske.
 
-Rollback = restore the Proxmox snapshot (whole appliance) or restore the HA
-backup (configuration only). Delete the snapshot once the stack is verified
-healthy — snapshots left on disk grow and violate `docs/storage-policy.md`.
+Tagasikerimine = taasta Proxmoxi snapshot (kogu seade) või taasta HA varukoopia
+(ainult konfiguratsioon). Kustuta snapshot, kui oled veendunud, et kõik töötab —
+kettale jäetud snapshotid kasvavad ja rikuvad `docs/storage-policy.md` reegleid.
 
-## Step 1 – Home Assistant Core
+## Samm 1 – Home Assistant Core
 
-Read the release notes for **every** version between the installed one and the
-target, specifically the "Breaking changes" section.
+Loe väljalaskemärkmed **iga** versiooni kohta paigaldatu ja sihtversiooni vahel,
+eriti jaotist „Breaking changes".
 
-Settings → System → Updates → *Home Assistant Core* → Update.
-Leave "Create backup before updating" enabled.
+Seaded → Süsteem → Uuendused → *Home Assistant Core* → Uuenda.
+Jäta „Loo enne uuendamist varukoopia" sisse lülitatuks.
 
-**Before updating Core, check custom integrations.** Custom components are the
-usual cause of a broken start after a Core upgrade. For this instance that
-means **Better Thermostat** (HACS) and the **Home Assistant MCP Server**:
-confirm the version you are moving to supports the target Core release. If it
-does not, update the integration first, or hold Core back.
+**Enne Core'i uuendamist kontrolli kohandatud integratsioone.** Kohandatud
+komponendid on tavaline põhjus, miks HA pärast Core'i uuendust ei käivitu.
+Selles instantsis tähendab see **Better Thermostati** (HACS) ja **Home Assistant
+MCP Serverit**: veendu, et versioon, kuhu liigud, toetab sihtversiooni Core'ist.
+Kui ei toeta, uuenda kõigepealt integratsiooni või hoia Core tagasi.
 
-**The recorder database migration is the slow part.** Some Core releases
-change the recorder schema and migrate the database *after* HA has already
-started. During that migration HA is reachable but sluggish, and history and
-the logbook are incomplete. On a long-lived database this runs for anything
-from a few minutes to several hours. **Do not restart HA, and do not reboot the
-VM, while it is running** — an interrupted migration is how the database gets
-corrupted. Watch the log for the migration to report finished; only then judge
-whether the update worked.
+**Recorderi andmebaasi migratsioon on aeglane osa.** Mõned Core'i väljalasked
+muudavad recorderi skeemi ja migreerivad andmebaasi *pärast* seda, kui HA on
+juba käivitunud. Migratsiooni ajal on HA kättesaadav, aga aeglane, ning ajalugu
+ja logiraamat on puudulikud. Pikalt kasutusel olnud andmebaasi puhul kestab see
+mõnest minutist mitme tunnini. **Ära tee HA-le restarti ega VM-ile
+alglaadimist, kui see käib** — katkestatud migratsioon on see, kuidas andmebaas
+rikutuks saab. Jälgi logist, kuni migratsioon teatab lõpetamisest; alles siis
+hinda, kas uuendus õnnestus.
 
-Verify: HA restarts, Settings → System → Repairs is clean, the garage
-automations still show as available (no `unavailable` entities). Give entities
-a few minutes to repopulate before treating an `unavailable` one as broken.
+Kontroll: HA käivitub, Seaded → Süsteem → Parandused on puhas, garaaži
+automaatikad on endiselt saadaval (`unavailable` olekus olemeid ei ole). Anna
+olemitele paar minutit taastumiseks, enne kui pead `unavailable` olekut rikkeks.
 
-## Step 2 – Home Assistant Operating System
+## Samm 2 – Home Assistant Operating System
 
-Settings → System → Updates → *Home Assistant Operating System* → Update.
+Seaded → Süsteem → Uuendused → *Home Assistant Operating System* → Uuenda.
 
-This reboots the whole appliance. Expect the VM to be unreachable for several
-minutes — the download runs first, then the reboot, and the first boot on a new
-OS version is slower than usual. **Do not force-stop the VM from Proxmox
-because the UI has not come back yet**; give it a good 15 minutes before
-treating it as hung. Do not run this step remotely unless you can reach the
-Proxmox console.
+See teeb kogu seadmele alglaadimise. Arvesta, et VM on mitu minutit
+kättesaamatu — kõigepealt käib allalaadimine, siis alglaadimine, ja esimene boot
+uue OS-i versiooniga on tavalisest aeglasem. **Ära peata VM-i Proxmoxist jõuga
+sellepärast, et kasutajaliides pole veel tagasi tulnud** — anna vähemalt 15
+minutit, enne kui pead seda kinnijooksnuks. Ära tee seda sammu eemalt, kui sa ei
+pääse Proxmoxi konsoolile.
 
-Verify: VM boots, HA UI returns, Settings → System → Hardware still lists the
-Zigbee coordinator (a USB passthrough that silently drops after a reboot is the
-failure mode to watch for here).
+Kontroll: VM käivitub, HA kasutajaliides tuleb tagasi, Seaded → Süsteem →
+Riistvara näitab endiselt Zigbee koordinaatorit (siin tuleb jälgida just seda,
+et USB läbiandmine ei kaoks pärast alglaadimist märkamatult ära).
 
-## Step 3 – Add-ons
+## Samm 3 – Lisandid
 
-Update one at a time, verifying between each:
+Uuenda ükshaaval, kontrollides iga uuenduse järel:
 
-1. **Zigbee2MQTT** — the highest-risk add-on. Confirm `coordinator_backup.json`
-   is current (Step 0), read the Z2M release notes for configuration migrations,
-   then update. Verify: add-on starts, and a round-trip works (toggle one
-   mains-powered device from HA and see the state come back).
+1. **Zigbee2MQTT** — kõige suurema riskiga lisand. Veendu, et
+   `coordinator_backup.json` on värske (samm 0), loe Z2M väljalaskemärkmetest
+   konfiguratsiooni migratsioonide kohta ja siis uuenda. Kontroll: lisand
+   käivitub ja edasi-tagasi käsklus töötab (lülita HA-st mõnda võrgutoitel
+   seadet ja vaata, kas olek tuleb tagasi).
 
-   **Do not expect the whole Zigbee network back immediately.** Mains-powered
-   routers rejoin within minutes. Battery devices only report when they next
-   wake up, which can be hours — a battery sensor still showing as unavailable
-   the same evening is normal and is not evidence that the update failed. Do
-   not re-pair anything on day one; re-pairing a device that was going to come
-   back on its own only makes the mesh worse.
-2. **Grafana** — low risk. Verify: dashboards render and the Prometheus data
-   source is still connected (see `monitoring/grafana/README.md`).
-3. **Home Assistant MCP Server** — verify the MCP client can still list tools
-   after the restart.
+   **Ära oota kogu Zigbee võrku kohe tagasi.** Võrgutoitel ruuterid liituvad
+   uuesti mõne minutiga. Patareitoitel seadmed raporteerivad alles siis, kui nad
+   järgmine kord ärkavad — see võib võtta tunde. Patareiandur, mis on samal
+   õhtul veel `unavailable`, on normaalne ega tõenda, et uuendus ebaõnnestus.
+   Ära seo esimesel päeval midagi uuesti: seadme uuesti sidumine, mis oleks
+   niikuinii ise tagasi tulnud, ainult halvendab mesh-võrku.
+2. **Grafana** — madal risk. Kontroll: töölauad renderduvad ja Prometheuse
+   andmeallikas on endiselt ühendatud (vaata `monitoring/grafana/README.md`).
+3. **Home Assistant MCP Server** — kontrolli, et MCP klient suudab pärast
+   taaskäivitust endiselt tööriistu loetleda.
 
-## Step 4 – Custom integrations (HACS)
+## Samm 4 – Kohandatud integratsioonid (HACS)
 
-**Better Thermostat**: update via HACS, then restart Home Assistant. Verify the
-climate entities are back and are not stuck in `unavailable`.
+**Better Thermostat**: uuenda HACS-i kaudu, seejärel taaskäivita Home Assistant.
+Kontrolli, et kliimaolemid on tagasi ega ole jäänud `unavailable` olekusse.
 
-Better Thermostat holds calibration state that is re-established after a
-restart, and that takes a full heating cycle — the valve position looking wrong
-in the first minutes after the restart is expected, not a fault. Check that the
-target temperature actually reaches the valve, then leave it alone for a cycle
-before concluding anything.
+Better Thermostat hoiab kalibratsiooniolekut, mis taastub pärast taaskäivitust,
+ja see võtab terve küttetsükli — ventiili asend võib esimestel minutitel pärast
+taaskäivitust vale välja näha, ja see on ootuspärane, mitte rike. Kontrolli, et
+seatud temperatuur jõuab tegelikult ventiilini, ja jäta siis üheks tsükliks
+rahule, enne kui midagi järeldad.
 
-## Step 5 – Shelly device firmware (last, one at a time)
+## Samm 5 – Shelly seadmete püsivara (viimasena, ükshaaval)
 
-Device firmware is updated **after** the platform is confirmed healthy, never
-in the same pass. A failed flash leaves the device offline until it is power
-cycled by hand.
+Seadmete püsivara uuendatakse **pärast** seda, kui platvormi tervis on
+kinnitatud, mitte kunagi samas käigus. Ebaõnnestunud välkimine jätab seadme
+võrgust välja, kuni sellel käsitsi voolu ei katkestata.
 
-For each device: check what it controls, confirm the load is idle, update,
-wait for it to come back, verify it responds from HA. Then move to the next.
+Iga seadme puhul: vaata, mida see juhib, veendu, et koormus on jõude, uuenda,
+oota, kuni seade tagasi tuleb, kontrolli, et see HA-st vastab. Alles siis järgmine.
 
-**Wait out each device before starting the next one.** A Shelly reboots and
-reconnects to Wi-Fi after flashing, which takes a few minutes; a Gen3 doing a
-two-stage update takes longer and can look dead in between. **Never cut power
-to a Shelly that is mid-update** — that is the one reliable way to brick it.
-Budget 5–10 minutes per device and do not batch them.
+**Oota iga seade lõpuni ära, enne kui järgmisega alustad.** Shelly teeb pärast
+välkimist alglaadimise ja ühendub Wi-Fi-ga uuesti, mis võtab mõne minuti;
+Gen3 kaheastmeline uuendus võtab kauem ja võib vahepeal surnud välja näha.
+**Ära kunagi katkesta voolu Shellyl, mille uuendus on pooleli** — see on ainus
+kindel viis see ära rikkuda. Arvesta 5–10 minutit seadme kohta ja ära tee neid
+partiidena.
 
-Current garage devices:
+Praegused garaaži seadmed:
 
-| Device | Model | Controls | Precondition |
+| Seade | Mudel | Mida juhib | Eeltingimus |
 | --- | --- | --- | --- |
-| `K1 Max – kapi vent` | Shelly 1 Mini | Cabinet fan | Printer idle and cool |
-| `K1 Max – printeri toide` | Shelly 1PM | Printer mains power | **No print running.** Cutting power mid-print destroys the job |
-| `Kapi all lambid` | Shelly 1 Mini | Under-cabinet lights | Nobody working in the cabinet |
-| `shelly1minig3-54320468c06c` | Shelly 1 Mini Gen3 | Unidentified — **identify before updating** | Load known and idle |
-| `shelly1minig3-dcda0ce25a78` | Shelly 1 Mini Gen3 | Unidentified — **identify before updating** | Load known and idle |
+| `K1 Max – kapi vent` | Shelly 1 Mini | Kapi ventilaator | Printer jõude ja jahtunud |
+| `K1 Max – printeri toide` | Shelly 1PM | Printeri võrgutoide | **Ükski print ei tohi käia.** Voolu katkestamine keset printimist hävitab töö |
+| `Kapi all lambid` | Shelly 1 Mini | Kapialused valgustid | Keegi ei tööta kapi juures |
+| `shelly1minig3-54320468c06c` | Shelly 1 Mini Gen3 | Tuvastamata — **tuvasta enne uuendamist** | Koormus teada ja jõude |
+| `shelly1minig3-dcda0ce25a78` | Shelly 1 Mini Gen3 | Tuvastamata — **tuvasta enne uuendamist** | Koormus teada ja jõude |
 
-Two devices still carry factory hostnames. Name them in Home Assistant before
-updating them — an unnamed relay is an unknown load, and updating an unknown
-load is how the printer loses power mid-print.
+Kaks seadet kannavad endiselt tehase hostinimesid. Anna neile Home Assistantis
+nimed, enne kui neid uuendad — nimetu relee on tundmatu koormus, ja tundmatu
+koormuse uuendamine on täpselt see, kuidas printer keset tööd voolu kaotab.
 
-## Step 6 – Close out
+## Samm 6 – Lõpetamine
 
-1. Confirm Settings → System → Updates is empty (or that anything left is
-   deliberately held, with the reason logged).
-2. Check Settings → System → Repairs and the error log.
-3. Delete the Proxmox snapshot from Step 0.
-4. Add an entry to `docs/operations/home-assistant-update-log.md`.
+1. Veendu, et Seaded → Süsteem → Uuendused on tühi (või et allesjäänu on
+   teadlikult tagasi hoitud ja põhjus on logitud).
+2. Vaata üle Seaded → Süsteem → Parandused ja vealogi.
+3. Kustuta sammus 0 tehtud Proxmoxi snapshot.
+4. Lisa kanne faili `docs/operations/home-assistant-update-log.md`.
 
-## Slow is not broken
+## Aeglane ei tähenda katki
 
-Most "the update broke everything" reports are an operator intervening too
-early. Before acting, check whether what you are seeing is on this list:
+Enamik „uuendus lõhkus kõik ära" teateid on operaator, kes sekkus liiga vara.
+Enne kui midagi ette võtad, vaata, kas see, mida sa näed, on siin nimekirjas:
 
-| What you see | Normal wait before it is a problem |
+| Mida sa näed | Kaua on normaalne oodata, enne kui see on probleem |
 | --- | --- |
-| HA sluggish, history gaps after a Core update | Until the recorder migration finishes — minutes to hours. Do not restart |
-| VM unreachable after the OS update | ~15 min, including download and a slow first boot |
-| Entities `unavailable` right after a restart | A few minutes while they repopulate |
-| Battery Zigbee devices missing after a Z2M update | Until they next wake — often hours. Do not re-pair |
-| Valve position looks wrong after Better Thermostat | One full heating cycle |
-| A Shelly offline right after flashing | Several minutes. Never cut its power meanwhile |
+| HA aeglane, ajaloos augud pärast Core'i uuendust | Kuni recorderi migratsioon lõpeb — minutid kuni tunnid. Ära tee restarti |
+| VM kättesaamatu pärast OS-i uuendust | ~15 min, sh allalaadimine ja aeglane esimene boot |
+| Olemid `unavailable` kohe pärast taaskäivitust | Paar minutit, kuni need taastuvad |
+| Patareitoitel Zigbee seadmed puudu pärast Z2M uuendust | Kuni nad järgmine kord ärkavad — sageli tunnid. Ära seo uuesti |
+| Ventiili asend paistab vale pärast Better Thermostati | Üks täielik küttetsükkel |
+| Shelly võrgust väljas kohe pärast välkimist | Mitu minutit. Ära vahepeal voolu katkesta |
 
-If it is still wrong after the wait, then it is a fault — see below.
+Kui pärast ootamist on ikka valesti, siis on tegu rikkega — vaata allpool.
 
-## If it breaks
+## Kui midagi läheb katki
 
-| Symptom | Action |
+| Sümptom | Tegevus |
 | --- | --- |
-| HA does not start after Core update | Restore the HA backup, or roll back Core from the CLI: `ha core update --version <previous>` |
-| Whole appliance unreachable after OS update | Proxmox console; if unrecoverable, restore the snapshot from Step 0 |
-| Zigbee devices all gone after Z2M update | Restore `coordinator_backup.json` and pin the previous Z2M version |
-| Zigbee coordinator missing after reboot | Check USB passthrough on the VM in Proxmox before re-pairing anything |
-| Shelly offline after firmware update | Power cycle at the breaker; if still dead, factory reset and re-adopt |
+| HA ei käivitu pärast Core'i uuendust | Taasta HA varukoopia või keri Core käsurealt tagasi: `ha core update --version <eelmine>` |
+| Kogu seade kättesaamatu pärast OS-i uuendust | Proxmoxi konsool; kui ei taastu, taasta sammu 0 snapshot |
+| Kõik Zigbee seadmed kadunud pärast Z2M uuendust | Taasta `coordinator_backup.json` ja fikseeri eelmine Z2M versioon |
+| Zigbee koordinaator puudu pärast alglaadimist | Kontrolli Proxmoxis VM-i USB läbiandmist, enne kui midagi uuesti seod |
+| Shelly võrgust väljas pärast püsivara uuendust | Katkesta kaitsmest vool; kui ikka surnud, tee tehaseseadete taastamine ja lisa uuesti |


### PR DESCRIPTION
## What

The Garaaž HA instance announced 11 pending updates in a single notification, spanning four different layers: Home Assistant Core, Home Assistant OS, three add-ons (Zigbee2MQTT, Grafana, MCP Server), one HACS custom integration (Better Thermostat), and five Shelly device firmwares. There was no documented procedure for applying them, so this adds one.

The documents are written in Estonian — the garage is operated in Estonian and the notifications that trigger this procedure arrive in Estonian, so the runbook is easier to follow under time pressure in the same language.

## Changes

- **`docs/operations/home-assistant-updates.md`** — ordered runbook:
  - Step 0 establishes the rollback path before anything is touched (full HA backup, copied off the VM, plus a running Proxmox snapshot and a current Zigbee coordinator backup).
  - Steps 1–5 apply one layer at a time with verification between each: Core → OS → add-ons → HACS → device firmware last.
  - Device firmware is explicitly separated from platform updates and is done one device at a time, with the controlled load identified and idle first.
  - A time budget with per-step estimates, and a "slow is not broken" table.
  - Closing checklist (Repairs clean, snapshot deleted, log entry written) and a symptom → recovery table.
- **`docs/operations/home-assistant-update-log.md`** — per-session log with an entry template, plus the 2026-08-31 batch recorded: all 11 updates classified by layer, risk and execution order, with the prerequisites that must clear first and a suggested three-session split.
- **`README.md`** — the runbook is linked from the daily operations list.

## Notes for review

Three things drove the shape of this and are worth a look:

- **Better Thermostat** is a HACS custom integration and is the most likely thing to break a Core upgrade, so the runbook requires checking its compatibility *before* Step 1 even though it is applied in Step 4.
- **Shelly firmware is last and manual.** `K1 Max – printeri toide` (Shelly 1PM) switches the 3D printer's mains power, and two Gen3 relays (`shelly1minig3-54320468c06c`, `shelly1minig3-dcda0ce25a78`) still carry factory hostnames — unknown loads. The runbook requires naming them before flashing and requires physical access, since a failed flash needs a power cycle.
- **Impatience is the real failure mode, so the timings are part of the procedure.** The recorder database migration after a Core update can run for hours with HA up but sluggish, and restarting during it corrupts the database. Battery Zigbee devices only report when they next wake, often hours after a Z2M update. Cutting power to a Shelly mid-flash bricks it. Each of those has an explicit "wait this long before treating it as a fault" entry.

## CI, and how to read this diff

CI is **green**. It did not start that way: `Ansible Lint` had never passed on `master` (19/19 runs failed since the workflow was added), so this PR inherited a red gate that had nothing to do with it. #5 fixes that, and I merged it into this branch (`04a9561`) so the result here is a real signal rather than an inherited failure. That merge no-ops once `master` carries #5.

**Review #5 first, then this one.** Everything under `ansible/`, plus `ansible.cfg` and `.github/workflows/ci.yml`, belongs to #5 and disappears from this diff once #5 lands. What is actually up for review here is `docs/operations/` and one line of `README.md`.