### PR TITLE
Fix Ansible Lint CI job and correct the timezone module in vm-base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         run: |
           pip install ansible-lint
 
+      - name: Install required Ansible collections
+        run: |
+          ansible-galaxy collection install -r ansible/requirements.yml
+
       - name: Run ansible-lint
         run: |
           ansible-lint ansible/

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,7 @@
+# Ansible configuration for this repository.
+#
+# Playbooks live in ansible/playbooks/ and roles in ansible/roles/, which is
+# not a layout Ansible discovers on its own. Without roles_path, both real
+# runs and ansible-lint fail with "the role '<name>' was not found".
+[defaults]
+roles_path = ansible/roles

--- a/ansible/group_vars/lab.yml
+++ b/ansible/group_vars/lab.yml
@@ -10,4 +10,3 @@ docker_users:
 
 # Example: More permissive settings for lab
 # vm_timezone: "America/New_York"  # Override default timezone if needed
-

--- a/ansible/group_vars/prod.yml
+++ b/ansible/group_vars/prod.yml
@@ -10,4 +10,3 @@ docker_users: []  # Empty by default - add users explicitly if needed
 # Example: Production-specific overrides
 # vm_timezone: "UTC"  # Explicit UTC for production
 # Additional production hardening can be added here
-

--- a/ansible/group_vars/proxmox_hosts.yml
+++ b/ansible/group_vars/proxmox_hosts.yml
@@ -80,4 +80,3 @@ admin_user_ssh_keys:
 
 # Node Exporter for monitoring (disabled by default; read-only metrics).
 node_exporter_enabled: false
-

--- a/ansible/group_vars/vms.yml
+++ b/ansible/group_vars/vms.yml
@@ -21,4 +21,3 @@ prometheus_enabled: false  # Set to true to enable Prometheus on monitoring VM
 
 # Grafana monitoring (optional)
 grafana_enabled: false  # Set to true to enable Grafana on monitoring VM
-

--- a/ansible/inventory.example.yml
+++ b/ansible/inventory.example.yml
@@ -37,4 +37,3 @@ all:
         ansible_user: "admin"
         ansible_port: 22
         ansible_ssh_common_args: '-o StrictHostKeyChecking=accept-new'
-

--- a/ansible/playbooks/host-audit.yml
+++ b/ansible/playbooks/host-audit.yml
@@ -74,13 +74,17 @@
       failed_when: false
 
     # Running services summary
-    - name: Get running services count
+    # The systemd module reports on one unit at a time; this audit wants the
+    # raw systemctl summary text verbatim for the report.
+    - name: Get running services count  # noqa: command-instead-of-module
       ansible.builtin.command:
         cmd: systemctl list-units --type=service --state=running --no-pager | wc -l
       register: running_services_count
       changed_when: false
 
-    - name: Get failed services
+    # The systemd module reports on one unit at a time; this audit wants the
+    # raw systemctl summary text verbatim for the report.
+    - name: Get failed services  # noqa: command-instead-of-module
       ansible.builtin.command:
         cmd: systemctl list-units --type=service --state=failed --no-pager || echo "No failed services"
       register: failed_services
@@ -92,61 +96,61 @@
       ansible.builtin.set_fact:
         host_audit_section: |
           ## Host: {{ inventory_hostname }}
-          
+
           ### System Information
           - **OS**: {{ ansible_distribution }} {{ ansible_distribution_version }}
           - **Kernel**: {{ ansible_kernel }}
           - **Architecture**: {{ ansible_architecture }}
           - **Uptime**: {{ ansible_uptime_seconds | int // 86400 }} days
-          
+
           ### Proxmox Version
           ```
           {{ pveversion_output.stdout | default('Not available') }}
           ```
-          
+
           ### CPU Information
           ```
           {{ cpu_info.stdout }}
           ```
-          
+
           ### Memory Summary
           ```
           {{ memory_info.stdout }}
           ```
-          
+
           ### Storage Devices
           **NVMe Devices:**
           ```
           {{ nvme_devices.stdout }}
           ```
-          
+
           **SSD/HDD Devices:**
           ```
           {{ ssd_devices.stdout }}
           ```
-          
+
           **ZFS Pools:**
           ```
           {{ zfs_pools.stdout }}
           ```
-          
+
           ### Network Interfaces
           ```
           {{ network_interfaces.stdout }}
           ```
-          
+
           **Network Bridges:**
           ```
           {{ network_bridges.stdout }}
           ```
-          
+
           ### Services
           - **Running services**: {{ running_services_count.stdout | trim }}
-          - **Failed services**: 
+          - **Failed services**:
           ```
           {{ failed_services.stdout }}
           ```
-          
+
           ---
 
   # Write all results to file in a single task
@@ -155,9 +159,9 @@
       ansible.builtin.set_fact:
         complete_audit_report: |
           # Proxmox Host Audit Report
-          
+
           Generated: {{ ansible_date_time.iso8601 }}
-          
+
           {% for host in groups['proxmox_hosts'] %}
           {{ hostvars[host]['host_audit_section'] | default('') }}
           {% endfor %}
@@ -171,4 +175,3 @@
         mode: '0644'
       delegate_to: localhost
       run_once: true
-

--- a/ansible/playbooks/vm-base.yml
+++ b/ansible/playbooks/vm-base.yml
@@ -49,7 +49,7 @@
 
     # Timezone configuration
     - name: Set timezone
-      ansible.builtin.timezone:
+      community.general.timezone:
         name: "{{ vm_timezone }}"
 
     # Basic SSH safety (LAN-friendly, not over-hardened)

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,6 @@
+---
+# Collections required by the playbooks and roles in this repository.
+# Install with: ansible-galaxy collection install -r ansible/requirements.yml
+collections:
+  - name: ansible.posix       # authorized_key, sysctl
+  - name: community.general   # timezone

--- a/ansible/roles/admin_user/tasks/main.yml
+++ b/ansible/roles/admin_user/tasks/main.yml
@@ -42,4 +42,3 @@
     content: "{{ admin_user_name }} ALL=(ALL) NOPASSWD:ALL\n"
     validate: "visudo -cf %s"
   when: admin_user_enabled | bool
-

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -69,4 +69,3 @@
 - name: Display Docker version
   ansible.builtin.debug:
     msg: "Docker installed: {{ docker_version.stdout | default('Unable to determine version') }}"
-

--- a/ansible/roles/grafana/files/dashboards.yml
+++ b/ansible/roles/grafana/files/dashboards.yml
@@ -11,4 +11,3 @@ providers:
     options:
       path: /etc/grafana/provisioning/dashboards
       foldersFromFilesStructure: false
-

--- a/ansible/roles/grafana/handlers/main.yml
+++ b/ansible/roles/grafana/handlers/main.yml
@@ -5,4 +5,3 @@
   ansible.builtin.service:
     name: grafana-server
     state: restarted
-

--- a/ansible/roles/grafana/tasks/main.yml
+++ b/ansible/roles/grafana/tasks/main.yml
@@ -84,7 +84,7 @@
     paths: "{{ playbook_dir }}/../../../monitoring/grafana/dashboards"
     patterns: "*.json"
     file_type: file
-  register: dashboard_files
+  register: grafana_dashboard_files
 
 - name: Deploy dashboard JSON files
   ansible.builtin.copy:
@@ -93,9 +93,9 @@
     owner: root
     group: root
     mode: '0644'
-  loop: "{{ dashboard_files.files }}"
+  loop: "{{ grafana_dashboard_files.files }}"
   notify: Restart grafana
-  when: dashboard_files.matched > 0
+  when: grafana_dashboard_files.matched > 0
 
 - name: Ensure Grafana service is enabled and running
   ansible.builtin.service:
@@ -103,7 +103,9 @@
     state: started
     enabled: true
 
-- name: Verify Grafana is listening on port 3000
+# A post-install verification, not a state change: it must run inline so a
+# failed install fails the play here, rather than at the end with the handlers.
+- name: Verify Grafana is listening on port 3000  # noqa: no-handler
   ansible.builtin.wait_for:
     port: 3000
     host: localhost
@@ -111,4 +113,3 @@
     timeout: 10
   delegate_to: localhost
   when: grafana_installed.changed
-

--- a/ansible/roles/node_exporter/handlers/main.yml
+++ b/ansible/roles/node_exporter/handlers/main.yml
@@ -5,4 +5,3 @@
   ansible.builtin.service:
     name: prometheus-node-exporter
     state: restarted
-

--- a/ansible/roles/node_exporter/tasks/main.yml
+++ b/ansible/roles/node_exporter/tasks/main.yml
@@ -17,7 +17,9 @@
     state: started
     enabled: true
 
-- name: Verify node_exporter is listening on port 9100
+# A post-install verification, not a state change: it must run inline so a
+# failed install fails the play here, rather than at the end with the handlers.
+- name: Verify node_exporter is listening on port 9100  # noqa: no-handler
   ansible.builtin.wait_for:
     port: 9100
     host: localhost
@@ -25,4 +27,3 @@
     timeout: 10
   delegate_to: localhost
   when: node_exporter_installed.changed
-

--- a/ansible/roles/prometheus/handlers/main.yml
+++ b/ansible/roles/prometheus/handlers/main.yml
@@ -5,4 +5,3 @@
   ansible.builtin.service:
     name: prometheus
     state: restarted
-

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -35,7 +35,9 @@
     state: started
     enabled: true
 
-- name: Verify Prometheus is listening on port 9090
+# A post-install verification, not a state change: it must run inline so a
+# failed install fails the play here, rather than at the end with the handlers.
+- name: Verify Prometheus is listening on port 9090  # noqa: no-handler
   ansible.builtin.wait_for:
     port: 9090
     host: localhost
@@ -43,4 +45,3 @@
     timeout: 10
   delegate_to: localhost
   when: prometheus_installed.changed
-

--- a/ansible/roles/ssh_keys/tasks/main.yml
+++ b/ansible/roles/ssh_keys/tasks/main.yml
@@ -35,4 +35,3 @@
     mode: "0600"
     content: "{{ (ssh_allowed_keys | join('\n')) ~ '\n' }}"
   when: ssh_keys_enforce | bool
-


### PR DESCRIPTION
## What

The `Ansible Lint` job has never passed. All 19 `CI Quality Gate` runs on `master` since the workflow was added in `48b550e` failed, including the current head — so the quality gate has been red on every commit and every PR since it was introduced, and has not been able to catch anything.

This gets it to green. Found while investigating why #4 (a docs-only PR) showed red CI.

## Root causes

Two of the four `syntax-check` errors were environmental, not code:

- **`roles_path` was never set.** Playbooks live in `ansible/playbooks/` and roles in `ansible/roles/`, which Ansible does not discover on its own — hence `the role 'ssh_keys' was not found` and `the role 'docker' was not found`. This broke real playbook runs too, not just the linter. Added an `ansible.cfg` at the repo root.
- **`ansible.posix` was never installed in CI**, so `ansible.posix.authorized_key` could not resolve in `roles/ssh_keys` and `roles/admin_user`. Added `ansible/requirements.yml` and an `ansible-galaxy collection install` step to the workflow.

## A real bug this was hiding

With `roles_path` set, `vm-base.yml` parses far enough to surface a fourth error that the role-not-found failure had been masking:

```
syntax-check[unknown-module]: couldn't resolve module/action 'ansible.builtin.timezone'
ansible/playbooks/vm-base.yml:51:7
```

There is no `ansible.builtin.timezone` — the module is in `community.general`. **The "Set timezone" task was failing at runtime on every `vm-base.yml` run**, not only under lint. Fixed, and `community.general` added to the requirements.

## The remaining findings

- **28 × `yaml[trailing-spaces]` / `yaml[empty-lines]`** — stripped trailing whitespace, collapsed double blank lines. This is the bulk of the diff and is whitespace-only; review with `git diff -w` to see the rest.
- **`var-naming[no-role-prefix]`** — `dashboard_files` → `grafana_dashboard_files` in the Grafana role.
- **2 × `command-instead-of-module`** — the `systemctl` calls in `host-audit.yml`. The `systemd` module reports on one unit at a time and cannot return the raw summary text the audit report captures, so these got a targeted `# noqa` with the reason rather than a rewrite.
- **3 × `no-handler`** — the "Verify X is listening on port N" tasks. These are post-install verifications, not state changes; as handlers they would run at the end of the play, so a failed install would be reported late instead of failing the play at that point. Targeted `# noqa` with the reason.

Nothing was skipped or disabled globally — `.ansible-lint` is unchanged and the `production` profile still applies.

## Verification

Reproduced the CI environment exactly (`ansible-lint` on `ansible-core`, no collections):

```
3 syntax-check profile:min tags:core,unskippable
Failed: 3 failure(s) ... Profile 'production' was required.
```

— exactly the failures CI reports. With the collections present:

```
Passed: 0 failure(s), 0 warning(s) in 26 files processed of 31 encountered.
Profile 'production' was required, and it passed.
```

**Confirmed on CI.** `galaxy.ansible.com` was blocked from the sandbox this was prepared in, so the `ansible-galaxy` step could not be exercised locally — only the end state it produces. CI has now run it: all three checks pass on `9ec0771`, the first green `CI Quality Gate` run in this repository.