### PR TITLE
Add agent environment policy: boundaries in permissions, not prompts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         run: |
           pip install ansible-lint
 
+      - name: Install required Ansible collections
+        run: |
+          ansible-galaxy collection install -r ansible/requirements.yml
+
       - name: Run ansible-lint
         run: |
           ansible-lint ansible/

--- a/README.md
+++ b/README.md
@@ -222,6 +222,20 @@ Every push runs:
 
 **Broken code should never reach production.**
 
+## Automation and AI agents
+
+If anything other than a human ever runs against this infrastructure — CI, a script on a
+timer, or an AI agent — read:
+
+**`docs/agent-environment.md`**
+
+It defines what an automated identity is allowed to do and, more importantly, how that is
+enforced: a plan-only Proxmox token, an unprivileged SSH user, branch protection.
+
+**Boundaries belong in permissions, not in prompts.**
+
+**An instruction is not a control. A missing credential is.**
+
 ## Final rule
 
 If you catch yourself thinking:

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,7 @@
+# Ansible configuration for this repository.
+#
+# Playbooks live in ansible/playbooks/ and roles in ansible/roles/, which is
+# not a layout Ansible discovers on its own. Without roles_path, both real
+# runs and ansible-lint fail with "the role '<name>' was not found".
+[defaults]
+roles_path = ansible/roles

--- a/ansible/group_vars/lab.yml
+++ b/ansible/group_vars/lab.yml
@@ -10,4 +10,3 @@ docker_users:
 
 # Example: More permissive settings for lab
 # vm_timezone: "America/New_York"  # Override default timezone if needed
-

--- a/ansible/group_vars/prod.yml
+++ b/ansible/group_vars/prod.yml
@@ -10,4 +10,3 @@ docker_users: []  # Empty by default - add users explicitly if needed
 # Example: Production-specific overrides
 # vm_timezone: "UTC"  # Explicit UTC for production
 # Additional production hardening can be added here
-

--- a/ansible/group_vars/proxmox_hosts.yml
+++ b/ansible/group_vars/proxmox_hosts.yml
@@ -80,4 +80,3 @@ admin_user_ssh_keys:
 
 # Node Exporter for monitoring (disabled by default; read-only metrics).
 node_exporter_enabled: false
-

--- a/ansible/group_vars/vms.yml
+++ b/ansible/group_vars/vms.yml
@@ -21,4 +21,3 @@ prometheus_enabled: false  # Set to true to enable Prometheus on monitoring VM
 
 # Grafana monitoring (optional)
 grafana_enabled: false  # Set to true to enable Grafana on monitoring VM
-

--- a/ansible/inventory.example.yml
+++ b/ansible/inventory.example.yml
@@ -37,4 +37,3 @@ all:
         ansible_user: "admin"
         ansible_port: 22
         ansible_ssh_common_args: '-o StrictHostKeyChecking=accept-new'
-

--- a/ansible/playbooks/host-audit.yml
+++ b/ansible/playbooks/host-audit.yml
@@ -74,13 +74,17 @@
       failed_when: false
 
     # Running services summary
-    - name: Get running services count
+    # The systemd module reports on one unit at a time; this audit wants the
+    # raw systemctl summary text verbatim for the report.
+    - name: Get running services count  # noqa: command-instead-of-module
       ansible.builtin.command:
         cmd: systemctl list-units --type=service --state=running --no-pager | wc -l
       register: running_services_count
       changed_when: false
 
-    - name: Get failed services
+    # The systemd module reports on one unit at a time; this audit wants the
+    # raw systemctl summary text verbatim for the report.
+    - name: Get failed services  # noqa: command-instead-of-module
       ansible.builtin.command:
         cmd: systemctl list-units --type=service --state=failed --no-pager || echo "No failed services"
       register: failed_services
@@ -92,61 +96,61 @@
       ansible.builtin.set_fact:
         host_audit_section: |
           ## Host: {{ inventory_hostname }}
-          
+
           ### System Information
           - **OS**: {{ ansible_distribution }} {{ ansible_distribution_version }}
           - **Kernel**: {{ ansible_kernel }}
           - **Architecture**: {{ ansible_architecture }}
           - **Uptime**: {{ ansible_uptime_seconds | int // 86400 }} days
-          
+
           ### Proxmox Version
           ```
           {{ pveversion_output.stdout | default('Not available') }}
           ```
-          
+
           ### CPU Information
           ```
           {{ cpu_info.stdout }}
           ```
-          
+
           ### Memory Summary
           ```
           {{ memory_info.stdout }}
           ```
-          
+
           ### Storage Devices
           **NVMe Devices:**
           ```
           {{ nvme_devices.stdout }}
           ```
-          
+
           **SSD/HDD Devices:**
           ```
           {{ ssd_devices.stdout }}
           ```
-          
+
           **ZFS Pools:**
           ```
           {{ zfs_pools.stdout }}
           ```
-          
+
           ### Network Interfaces
           ```
           {{ network_interfaces.stdout }}
           ```
-          
+
           **Network Bridges:**
           ```
           {{ network_bridges.stdout }}
           ```
-          
+
           ### Services
           - **Running services**: {{ running_services_count.stdout | trim }}
-          - **Failed services**: 
+          - **Failed services**:
           ```
           {{ failed_services.stdout }}
           ```
-          
+
           ---
 
   # Write all results to file in a single task
@@ -155,9 +159,9 @@
       ansible.builtin.set_fact:
         complete_audit_report: |
           # Proxmox Host Audit Report
-          
+
           Generated: {{ ansible_date_time.iso8601 }}
-          
+
           {% for host in groups['proxmox_hosts'] %}
           {{ hostvars[host]['host_audit_section'] | default('') }}
           {% endfor %}
@@ -171,4 +175,3 @@
         mode: '0644'
       delegate_to: localhost
       run_once: true
-

--- a/ansible/playbooks/vm-base.yml
+++ b/ansible/playbooks/vm-base.yml
@@ -49,7 +49,7 @@
 
     # Timezone configuration
     - name: Set timezone
-      ansible.builtin.timezone:
+      community.general.timezone:
         name: "{{ vm_timezone }}"
 
     # Basic SSH safety (LAN-friendly, not over-hardened)

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,6 @@
+---
+# Collections required by the playbooks and roles in this repository.
+# Install with: ansible-galaxy collection install -r ansible/requirements.yml
+collections:
+  - name: ansible.posix       # authorized_key, sysctl
+  - name: community.general   # timezone

--- a/ansible/roles/admin_user/tasks/main.yml
+++ b/ansible/roles/admin_user/tasks/main.yml
@@ -42,4 +42,3 @@
     content: "{{ admin_user_name }} ALL=(ALL) NOPASSWD:ALL\n"
     validate: "visudo -cf %s"
   when: admin_user_enabled | bool
-

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -69,4 +69,3 @@
 - name: Display Docker version
   ansible.builtin.debug:
     msg: "Docker installed: {{ docker_version.stdout | default('Unable to determine version') }}"
-

--- a/ansible/roles/grafana/files/dashboards.yml
+++ b/ansible/roles/grafana/files/dashboards.yml
@@ -11,4 +11,3 @@ providers:
     options:
       path: /etc/grafana/provisioning/dashboards
       foldersFromFilesStructure: false
-

--- a/ansible/roles/grafana/handlers/main.yml
+++ b/ansible/roles/grafana/handlers/main.yml
@@ -5,4 +5,3 @@
   ansible.builtin.service:
     name: grafana-server
     state: restarted
-

--- a/ansible/roles/grafana/tasks/main.yml
+++ b/ansible/roles/grafana/tasks/main.yml
@@ -84,7 +84,7 @@
     paths: "{{ playbook_dir }}/../../../monitoring/grafana/dashboards"
     patterns: "*.json"
     file_type: file
-  register: dashboard_files
+  register: grafana_dashboard_files
 
 - name: Deploy dashboard JSON files
   ansible.builtin.copy:
@@ -93,9 +93,9 @@
     owner: root
     group: root
     mode: '0644'
-  loop: "{{ dashboard_files.files }}"
+  loop: "{{ grafana_dashboard_files.files }}"
   notify: Restart grafana
-  when: dashboard_files.matched > 0
+  when: grafana_dashboard_files.matched > 0
 
 - name: Ensure Grafana service is enabled and running
   ansible.builtin.service:
@@ -103,7 +103,9 @@
     state: started
     enabled: true
 
-- name: Verify Grafana is listening on port 3000
+# A post-install verification, not a state change: it must run inline so a
+# failed install fails the play here, rather than at the end with the handlers.
+- name: Verify Grafana is listening on port 3000  # noqa: no-handler
   ansible.builtin.wait_for:
     port: 3000
     host: localhost
@@ -111,4 +113,3 @@
     timeout: 10
   delegate_to: localhost
   when: grafana_installed.changed
-

--- a/ansible/roles/node_exporter/handlers/main.yml
+++ b/ansible/roles/node_exporter/handlers/main.yml
@@ -5,4 +5,3 @@
   ansible.builtin.service:
     name: prometheus-node-exporter
     state: restarted
-

--- a/ansible/roles/node_exporter/tasks/main.yml
+++ b/ansible/roles/node_exporter/tasks/main.yml
@@ -17,7 +17,9 @@
     state: started
     enabled: true
 
-- name: Verify node_exporter is listening on port 9100
+# A post-install verification, not a state change: it must run inline so a
+# failed install fails the play here, rather than at the end with the handlers.
+- name: Verify node_exporter is listening on port 9100  # noqa: no-handler
   ansible.builtin.wait_for:
     port: 9100
     host: localhost
@@ -25,4 +27,3 @@
     timeout: 10
   delegate_to: localhost
   when: node_exporter_installed.changed
-

--- a/ansible/roles/prometheus/handlers/main.yml
+++ b/ansible/roles/prometheus/handlers/main.yml
@@ -5,4 +5,3 @@
   ansible.builtin.service:
     name: prometheus
     state: restarted
-

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -35,7 +35,9 @@
     state: started
     enabled: true
 
-- name: Verify Prometheus is listening on port 9090
+# A post-install verification, not a state change: it must run inline so a
+# failed install fails the play here, rather than at the end with the handlers.
+- name: Verify Prometheus is listening on port 9090  # noqa: no-handler
   ansible.builtin.wait_for:
     port: 9090
     host: localhost
@@ -43,4 +45,3 @@
     timeout: 10
   delegate_to: localhost
   when: prometheus_installed.changed
-

--- a/ansible/roles/ssh_keys/tasks/main.yml
+++ b/ansible/roles/ssh_keys/tasks/main.yml
@@ -35,4 +35,3 @@
     mode: "0600"
     content: "{{ (ssh_allowed_keys | join('\n')) ~ '\n' }}"
   when: ssh_keys_enforce | bool
-

--- a/docs/agent-environment.md
+++ b/docs/agent-environment.md
@@ -1,0 +1,247 @@
+# Agent Environment Policy
+
+## Why this document exists
+
+Most automation is written as a task list: "clone the template, then add the VM to
+inventory, then run the playbook". That model assumes a human executor who works in
+sequence and asks before doing anything unusual.
+
+An AI agent is not that executor. It works in parallel, it does not ask, and it reads
+whatever it is allowed to read. Telling it what to do in a prompt is not a control —
+a prompt is a suggestion the model may reinterpret. **The only real control is what the
+credentials permit.**
+
+So this repository takes the opposite approach to agent automation:
+
+- **A human is directed with tasks.**
+- **An agent is directed with an environment.**
+
+Give an agent a goal, a way to see the current state, a reviewer that rejects bad work,
+and rights that make the destructive paths physically unreachable. Then let it work.
+
+**Boundaries belong in permissions, not in prompts.**
+
+## The four parts of an agent environment
+
+Any usable agent setup needs the same four pieces. This section maps each one onto
+things that already exist in this repository.
+
+### 1. Goal and metric
+
+An agent without a measurable goal produces plausible-looking churn. Every agent task
+in this repo must state its goal as a checkable condition, not as an activity.
+
+Acceptable goals — each one is a command whose output decides pass/fail:
+
+| Goal | How it is measured |
+|---|---|
+| Hosts match declared configuration | `ansible-playbook ... --check --diff` reports no changes |
+| Infrastructure matches code | `terraform plan` reports no changes |
+| Repository is lintable | CI quality gate is green (see `.github/workflows/ci.yml`) |
+| Hosts are healthy | Prometheus targets up, no firing alerts (see `monitoring/`) |
+| Storage is policy-compliant | No configuration violates `docs/storage-policy.md` |
+
+Unacceptable goals: "improve the Ansible roles", "clean up Terraform", "harden the
+hosts". These have no failure condition, so the agent cannot tell when to stop.
+
+### 2. Archive — the agent must be able to see what is already done
+
+An agent picks up work from written state, not from a meeting. If the state is not
+written down, the agent will re-derive it, guess it, or rediscover an incident the hard
+way. This repository is already built as such an archive; that property is now load-bearing:
+
+- `git log` — what changed, when, and why
+- `docs/` — architecture, policies, and decisions (`storage-decisions.md`,
+  `storage-policy.md`, `ssh-key-policy.md`)
+- `docs/operations/` — the supported procedures; if it is not written there, it is not supported
+- `ansible/playbooks/host-audit.yml` — read-only host reality, on demand
+- `terraform plan` — the gap between declared and actual infrastructure
+
+The audit playbook and `terraform plan` are the important ones: they are the only way an
+agent can learn the *current* state without changing it. Both are read-only by
+construction, and must stay that way.
+
+**Rule:** any incident, workaround, or manual fix must land in `docs/` in the same change
+that fixes it. An undocumented fix is invisible to the next agent, which means it will be
+undone.
+
+### 3. Mailbox — how work is handed over
+
+Agents hand work to each other and to humans through the repository, not through chat:
+
+- A branch and a pull request per unit of work
+- Commit messages that state the reason, not the diff
+- Documentation updated in the same PR as the change
+
+An agent that finishes half a task must leave the half-finished state readable — an open
+PR with a description of what remains — so the next run continues instead of restarting.
+
+### 4. Reviewer — something that rejects bad work
+
+Without a reviewer, an environment-driven agent optimises for volume. The CI quality gate
+in `.github/workflows/ci.yml` is that reviewer: `ansible-lint`, `terraform fmt -check`,
+`terraform validate`. It runs on every push and pull request, and it deploys nothing.
+
+The reviewer is a machine, not the agent's own judgement. An agent may not merge on the
+grounds that it believes the work is correct.
+
+Current gaps in the reviewer are listed under [Gaps](#gaps-to-close) below.
+
+## Rights, not prompts
+
+This is the part that actually matters. Everything above shapes what an agent *does*;
+this section decides what it *can* do.
+
+### The blast radius in this repository
+
+Damage here is not evenly spread. Three areas cause real, expensive loss:
+
+1. **Storage changes.** Documented in `docs/storage-policy.md`, which exists because of a
+   production incident. Storage decisions are hard to reverse.
+2. **VM destruction.** `terraform apply` can destroy a VM and its disk in one step.
+3. **SSH key enforcement.** `ssh_keys_enforce: true` rewrites `authorized_keys` — on a
+   Proxmox cluster that is the shared `/etc/pve/priv/authorized_keys`. A wrong key list
+   locks every administrator out of every node.
+
+Everything else — linting, docs, monitoring dashboards, role refactors — is cheap to get
+wrong and cheap to revert. That asymmetry is the design input: **the read and plan plane
+stays wide open, the write plane stays narrow.**
+
+### Permission matrix
+
+| Action | Agent | Enforced by |
+|---|---|---|
+| Read the repository, run linters | Yes | No credential needed |
+| `ansible-playbook --check --diff` | Yes | Read-only Ansible user (see below) |
+| `ansible/playbooks/host-audit.yml` | Yes | Read-only by construction |
+| `terraform plan` | Yes | Plan-only Proxmox API token |
+| Open a branch and a pull request | Yes | Repository write, no merge |
+| Merge to `master` | No | Branch protection + required CI |
+| `terraform apply` (create/update) | No | Token lacking `VM.Allocate` / `Datastore.Allocate` |
+| `terraform destroy`, any VM deletion | No | Token lacking `VM.Allocate`; `prevent_destroy` |
+| Ansible apply run (no `--check`) | No | Read-only SSH user, no sudo |
+| Storage configuration changes | No | Not reachable by the token; policy review required |
+| `ssh_keys_enforce: true` | No | Human, with console access open |
+| API token creation or rotation | No | Human, Proxmox UI |
+
+The right-hand column is the point. Each "No" is a credential that does not exist for the
+agent, not an instruction it was asked to follow.
+
+### Proxmox: two tokens, not one
+
+`docs/terraform-proxmox-api-token.md` describes one token holding the full write set
+(`VM.Allocate`, `VM.Clone`, `VM.Config.*`, `VM.PowerMgmt`, `Datastore.Allocate`,
+`Datastore.AllocateSpace`). That token is correct for an operator running `terraform apply`.
+It must never be the token an agent holds.
+
+Create a second, separate token for agent and CI use:
+
+- **User:** a dedicated `agent@pve` user — not `root@pam`, not the Terraform user
+- **Privilege separation:** enabled
+- **Role:** a custom role, e.g. `terraform-planner`, holding only:
+  - `VM.Audit`
+  - `Datastore.Audit`
+  - `Sys.Audit`
+- **Path:** scope the ACL to the VM pool in use, not to `/`
+- **Expiration:** set one; a non-expiring agent token is a permanent liability
+
+This is enough for `terraform plan` and for reading state. It cannot create, clone,
+reconfigure, power-cycle, or delete anything. If an agent's plan requires an apply, a
+human runs the apply with the operator token.
+
+Verify which token you are holding before running anything:
+
+```bash
+./scripts/check-proxmox-token-permissions.sh
+```
+
+### SSH: the agent is not root
+
+The Ansible path needs the same split:
+
+- The agent connects as an unprivileged user with **no** `sudo` rights, sufficient for
+  `--check` runs and fact gathering.
+- `root` on Proxmox hosts stays with humans and console recovery. See the SSH policy in
+  `docs/architecture.md` and `docs/ssh-key-policy.md`.
+- `ssh_keys_enforce` stays `false` for every agent-reachable path. Enforcement is a
+  human action, performed with a console session already open, per
+  `docs/operations/ssh-key-rotation.md`.
+
+An agent that cannot become root cannot lock anyone out, regardless of what it decides
+to do.
+
+### Terraform: guards in code
+
+`prevent_destroy = true` is already set on the monitoring VMs in `terraform/main.tf`.
+Set it on every VM that holds state or that something depends on. It is not a substitute
+for token scoping — an agent with an apply token could remove the guard and then apply —
+but combined with a plan-only token it makes destruction unreachable from two directions.
+
+### Secrets
+
+`terraform.tfvars`, `ansible/inventory.yml`, and API token secrets are not committed and
+must not be readable by an agent that opens pull requests. An agent's run environment
+should carry the plan token and nothing else. Anything an agent can read, it can
+inadvertently write into a diff or a PR description.
+
+## The rest cycle: scheduled read-only runs
+
+Station's agents were given cycles where work was forbidden and only reflection was
+allowed. The infrastructure equivalent is a scheduled run that is allowed to look and
+report, but not to change:
+
+- `ansible-playbook ... --check --diff` against all hosts → configuration drift
+- `terraform plan` → infrastructure drift
+- `ansible/playbooks/host-audit.yml` → hardware, storage, and version reality
+- A check of monitoring targets and firing alerts
+
+The output is a report or an issue, never a change. Drift found this way is the most
+valuable input an agent environment produces, because it is the difference between what
+the repository claims and what the hardware is actually doing — and nobody notices it
+during normal work.
+
+## Where the analogy breaks
+
+The Station experiment ran in mathematics, where a wrong result costs nothing: the
+reviewer rejects it and the agent moves on. Infrastructure is not that domain. A wrong
+`terraform apply` destroys a disk; a wrong `authorized_keys` locks out every
+administrator. There is no reviewer that catches it after the fact.
+
+So the model is adopted asymmetrically, and deliberately:
+
+- **Exploration is unbounded** in the read and plan plane — reading, auditing, planning,
+  linting, drafting documentation and pull requests.
+- **The write plane stays narrow and human-gated**, exactly where `docs/storage-policy.md`
+  already says the expensive mistakes live.
+
+Autonomy is granted where mistakes are cheap and reversible. It is not granted where they
+are not. That boundary is drawn in the Proxmox role and the SSH user — where it can be
+verified — and not in an instruction anyone can talk their way past.
+
+## Gaps to close
+
+The environment described above is not fully in place. Current state:
+
+- [ ] **No plan-only Proxmox token documented.** `docs/terraform-proxmox-api-token.md`
+      describes only the full-write operator token. Add the `terraform-planner` role and
+      the `agent@pve` user.
+- [ ] **No branch protection on `master`.** CI runs, but nothing prevents a direct push or
+      a merge with a red gate. Require the quality gate and at least one review.
+- [ ] **No `CODEOWNERS`.** `docs/storage-policy.md`, `docs/ssh-key-policy.md`, and
+      `terraform/` should require named human review on change.
+- [ ] **CI checks style, not policy.** `ansible-lint` and `terraform validate` do not
+      catch a ZFS datastore on consumer hardware, `ssh_keys_enforce: true`, or a removed
+      `prevent_destroy`. These are the changes worth failing a build over — add a policy
+      check job.
+- [ ] **No scheduled drift run.** The read-only checks above exist but are only run by
+      hand, which means they are run after an incident rather than before one.
+- [ ] **No read-only Ansible user defined.** `ansible/group_vars/proxmox_hosts.yml`
+      configures the admin user; there is no unprivileged, sudo-less agent user.
+
+Close these before granting any agent scheduled or unattended access to the hosts.
+
+## Document control
+
+**Review frequency:** whenever agent access, API tokens, or CI gating changes.
+
+**Approval required:** for any change that widens what an automated identity may do.

--- a/docs/agent-environment.md
+++ b/docs/agent-environment.md
@@ -37,7 +37,7 @@ Acceptable goals — each one is a command whose output decides pass/fail:
 |---|---|
 | Hosts match declared configuration | `ansible-playbook ... --check --diff` reports no changes |
 | Infrastructure matches code | `terraform plan` reports no changes |
-| Repository is lintable | CI quality gate is green (see `.github/workflows/ci.yml`) — currently unattainable, see [Reviewer](#4-reviewer--something-that-rejects-bad-work) |
+| Repository is lintable | CI quality gate is green (see `.github/workflows/ci.yml`) |
 | Hosts are healthy | Prometheus targets up, no firing alerts (see `monitoring/`) |
 | Storage is policy-compliant | No configuration violates `docs/storage-policy.md` |
 
@@ -85,19 +85,22 @@ in `.github/workflows/ci.yml` is that reviewer: `ansible-lint`, `terraform fmt -
 The reviewer is a machine, not the agent's own judgement. An agent may not merge on the
 grounds that it believes the work is correct.
 
-**The reviewer currently does not work.** The `Ansible Lint` job has failed on every run
-of the quality gate since it was added, including every commit on `master`. A gate that
-rejects everything gates nothing: it cannot distinguish a good change from a bad one, so
-nobody can use it as a merge condition, and in practice it is ignored. Known causes:
-`roles_path` is not configured, so `ansible-lint` cannot resolve `ssh_keys`, `docker`, and
-the other roles from `ansible/playbooks/`; the `ansible.posix` collection is not installed
-in CI, so `ansible.posix.authorized_key` does not resolve; and `profile: production` in
-`.ansible-lint` enforces rules the roles do not currently satisfy, alongside trailing
-whitespace and blank-line findings.
+**The reviewer did not work until now.** The `Ansible Lint` job failed on every run of the
+quality gate from the day it was added through all 19 runs on `master`. A gate that rejects
+everything gates nothing: it cannot distinguish a good change from a bad one, so nobody can
+use it as a merge condition, and in practice it was ignored. Three causes: `roles_path` was
+unset, so `ansible-lint` could not resolve `ssh_keys`, `docker`, and the other roles from
+`ansible/playbooks/`; the required collections were neither declared nor installed in CI, so
+`ansible.posix.authorized_key` did not resolve; and the roles did not satisfy the
+`production` profile set in `.ansible-lint`.
 
-Fixing this is the first prerequisite for anything in this document. Until the gate is
-green on `master`, "CI is green" is not a usable metric and no automated identity should
-be granted anything beyond read access.
+The fix — `ansible.cfg` with `roles_path`, `ansible/requirements.yml` installed by the lint
+job, and the `production` profile findings resolved — is carried in this change and also
+lives on its own in the pull request that first made it. Once it is on `master`, "CI is
+green" becomes a usable metric for the first time.
+
+Until then, no automated identity should be granted anything beyond read access: a green
+gate is the precondition for every permission described below.
 
 ## Rights, not prompts
 
@@ -245,9 +248,10 @@ The environment described above is not fully in place. Current state:
       catch a ZFS datastore on consumer hardware, `ssh_keys_enforce: true`, or a removed
       `prevent_destroy`. These are the changes worth failing a build over — add a policy
       check job.
-- [ ] **The quality gate has never passed.** `Ansible Lint` has failed on all 19 runs on
-      `master`. Fix `roles_path`, install `ansible.posix` in CI, and either satisfy or
-      explicitly relax the `production` profile. This blocks every other item here.
+- [x] **The quality gate had never passed.** `Ansible Lint` failed on all 19 runs on
+      `master`. Fixed by configuring `roles_path`, declaring and installing the required
+      collections in CI, and resolving the `production` profile findings. Not yet on
+      `master` — it blocks every other item here until it is merged.
 - [ ] **No scheduled drift run.** The read-only checks above exist but are only run by
       hand, which means they are run after an incident rather than before one.
 - [ ] **No read-only Ansible user defined.** `ansible/group_vars/proxmox_hosts.yml`

--- a/docs/agent-environment.md
+++ b/docs/agent-environment.md
@@ -37,7 +37,7 @@ Acceptable goals — each one is a command whose output decides pass/fail:
 |---|---|
 | Hosts match declared configuration | `ansible-playbook ... --check --diff` reports no changes |
 | Infrastructure matches code | `terraform plan` reports no changes |
-| Repository is lintable | CI quality gate is green (see `.github/workflows/ci.yml`) |
+| Repository is lintable | CI quality gate is green (see `.github/workflows/ci.yml`) — currently unattainable, see [Reviewer](#4-reviewer--something-that-rejects-bad-work) |
 | Hosts are healthy | Prometheus targets up, no firing alerts (see `monitoring/`) |
 | Storage is policy-compliant | No configuration violates `docs/storage-policy.md` |
 
@@ -85,7 +85,19 @@ in `.github/workflows/ci.yml` is that reviewer: `ansible-lint`, `terraform fmt -
 The reviewer is a machine, not the agent's own judgement. An agent may not merge on the
 grounds that it believes the work is correct.
 
-Current gaps in the reviewer are listed under [Gaps](#gaps-to-close) below.
+**The reviewer currently does not work.** The `Ansible Lint` job has failed on every run
+of the quality gate since it was added, including every commit on `master`. A gate that
+rejects everything gates nothing: it cannot distinguish a good change from a bad one, so
+nobody can use it as a merge condition, and in practice it is ignored. Known causes:
+`roles_path` is not configured, so `ansible-lint` cannot resolve `ssh_keys`, `docker`, and
+the other roles from `ansible/playbooks/`; the `ansible.posix` collection is not installed
+in CI, so `ansible.posix.authorized_key` does not resolve; and `profile: production` in
+`.ansible-lint` enforces rules the roles do not currently satisfy, alongside trailing
+whitespace and blank-line findings.
+
+Fixing this is the first prerequisite for anything in this document. Until the gate is
+green on `master`, "CI is green" is not a usable metric and no automated identity should
+be granted anything beyond read access.
 
 ## Rights, not prompts
 
@@ -233,6 +245,9 @@ The environment described above is not fully in place. Current state:
       catch a ZFS datastore on consumer hardware, `ssh_keys_enforce: true`, or a removed
       `prevent_destroy`. These are the changes worth failing a build over — add a policy
       check job.
+- [ ] **The quality gate has never passed.** `Ansible Lint` has failed on all 19 runs on
+      `master`. Fix `roles_path`, install `ansible.posix` in CI, and either satisfy or
+      explicitly relax the `production` profile. This blocks every other item here.
 - [ ] **No scheduled drift run.** The read-only checks above exist but are only run by
       hand, which means they are run after an incident rather than before one.
 - [ ] **No read-only Ansible user defined.** `ansible/group_vars/proxmox_hosts.yml`

--- a/docs/agent-environment.md
+++ b/docs/agent-environment.md
@@ -255,6 +255,12 @@ The environment described above is not fully in place. Current state:
 
 Close these before granting any agent scheduled or unattended access to the hosts.
 
+## Obsidian copy
+
+An Obsidian-formatted version of this document — split into linked notes with frontmatter,
+callouts, and task checkboxes — lives in `docs/obsidian/`. Copy that folder into a vault, or
+open `docs/` as one. This file remains canonical; update it first.
+
 ## Document control
 
 **Review frequency:** whenever agent access, API tokens, or CI gating changes.

--- a/docs/obsidian/Agent Environment Gaps.md
+++ b/docs/obsidian/Agent Environment Gaps.md
@@ -20,9 +20,10 @@ items, not claims about current state.
 
 > [!caution] Close these before granting any agent scheduled or unattended access to the hosts.
 
-- [ ] **The quality gate has never passed.** `Ansible Lint` has failed on all 19 runs on
-      `master`. Fix `roles_path`, install `ansible.posix` in CI, and either satisfy or explicitly
-      relax the `production` profile. **This blocks every other item here.** → [[CI Quality Gate]]
+- [x] **The quality gate had never passed.** `Ansible Lint` failed on all 19 runs on `master`.
+      Fixed: `roles_path` configured, collections declared and installed in CI, `production`
+      profile findings resolved. **Still blocks every other item here until it reaches
+      `master`.** → [[CI Quality Gate]]
 - [ ] **No plan-only Proxmox token documented.** `docs/terraform-proxmox-api-token.md` describes
       only the full-write operator token. Add the `terraform-planner` role and the `agent@pve`
       user. → [[Plan-Only Proxmox Token]]

--- a/docs/obsidian/Agent Environment Gaps.md
+++ b/docs/obsidian/Agent Environment Gaps.md
@@ -1,0 +1,59 @@
+---
+title: Agent Environment Gaps
+aliases:
+  - Lüngad
+  - Agent readiness checklist
+tags:
+  - checklist
+  - blocker
+  - proxmox
+  - ai-agents
+repo: insippo/proxmox-infra
+source: docs/agent-environment.md
+up: "[[Agent Environment]]"
+---
+
+# Agent Environment Gaps
+
+The environment described in [[Agent Environment]] is **not yet in place**. These are open
+items, not claims about current state.
+
+> [!caution] Close these before granting any agent scheduled or unattended access to the hosts.
+
+- [ ] **The quality gate has never passed.** `Ansible Lint` has failed on all 19 runs on
+      `master`. Fix `roles_path`, install `ansible.posix` in CI, and either satisfy or explicitly
+      relax the `production` profile. **This blocks every other item here.** → [[CI Quality Gate]]
+- [ ] **No plan-only Proxmox token documented.** `docs/terraform-proxmox-api-token.md` describes
+      only the full-write operator token. Add the `terraform-planner` role and the `agent@pve`
+      user. → [[Plan-Only Proxmox Token]]
+- [ ] **No branch protection on `master`.** CI runs, but nothing prevents a direct push or a
+      merge with a red gate. Require the quality gate and at least one review.
+- [ ] **No `CODEOWNERS`.** The storage policy, the SSH key policy, and `terraform/` should
+      require named human review on change.
+- [ ] **CI checks style, not policy.** `ansible-lint` and `terraform validate` do not catch a ZFS
+      datastore on consumer hardware, `ssh_keys_enforce: true`, or a removed `prevent_destroy`.
+      Those are the changes worth failing a build over — add a policy check job.
+- [ ] **No scheduled drift run.** The read-only checks exist but are only run by hand, which means
+      they are run *after* an incident rather than before one.
+- [ ] **No read-only Ansible user defined.** `ansible/group_vars/proxmox_hosts.yml` configures the
+      admin user; there is no unprivileged, sudo-less agent user. → [[Rights Not Prompts]]
+
+## Ordering
+
+```mermaid
+flowchart TD
+    A["Fix CI quality gate"] --> B["Branch protection + CODEOWNERS"]
+    A --> C["Policy check job in CI"]
+    D["Plan-only Proxmox token"] --> F["Scheduled drift run"]
+    E["Read-only Ansible user"] --> F
+    B --> G["Unattended agent access"]
+    C --> G
+    F --> G
+```
+
+## Related
+
+- [[Agent Environment]]
+- [[CI Quality Gate]]
+- [[Plan-Only Proxmox Token]]
+- [[Rights Not Prompts]]

--- a/docs/obsidian/Agent Environment.md
+++ b/docs/obsidian/Agent Environment.md
@@ -1,0 +1,121 @@
+---
+title: Agent Environment
+aliases:
+  - Agent Environment MOC
+  - Agendikeskkond
+tags:
+  - moc
+  - proxmox
+  - automation
+  - ai-agents
+  - policy
+repo: insippo/proxmox-infra
+source: docs/agent-environment.md
+status: draft
+---
+
+# Agent Environment
+
+> [!abstract] The whole idea in two lines
+> **A human is directed with tasks. An agent is directed with an environment.**
+> Give it a goal, a way to see the current state, a reviewer that rejects bad work, and
+> rights that make the destructive paths unreachable. Then let it work.
+
+This is the map of content for how automated identities — CI, scheduled scripts, AI agents —
+are allowed to operate against the Proxmox infrastructure in `insippo/proxmox-infra`.
+
+Canonical version lives in the repository at `docs/agent-environment.md`. These notes are the
+vault copy; when they disagree, the repository wins.
+
+## Start here
+
+- [[Rights Not Prompts]] — the core principle and the blast radius it is drawn around
+- [[Agent Permission Matrix]] — what an agent may do, and what enforces each "no"
+- [[Plan-Only Proxmox Token]] — the concrete credential split
+- [[CI Quality Gate]] — the reviewer, and why it does not currently work
+- [[Agent Environment Gaps]] — what has to be built before granting unattended access
+
+## The four parts of an agent environment
+
+Any usable agent setup needs the same four pieces. Each maps onto something that already
+exists in the repository.
+
+| Part | What it does | Where it lives here |
+|---|---|---|
+| **Goal and metric** | Gives a checkable stopping condition | See [[#Goals that work]] |
+| **Archive** | Lets the agent see what is already done | `git log`, `docs/`, `host-audit.yml`, `terraform plan` |
+| **Mailbox** | Hands work between agents and humans | Branches, pull requests, commit messages |
+| **Reviewer** | Rejects bad work | [[CI Quality Gate]] |
+
+### Goals that work
+
+A goal must be a command whose output decides pass/fail. Anything else produces
+plausible-looking churn.
+
+| Goal | How it is measured |
+|---|---|
+| Hosts match declared configuration | `ansible-playbook … --check --diff` reports no changes |
+| Infrastructure matches code | `terraform plan` reports no changes |
+| Repository is lintable | CI quality gate is green — **currently unattainable**, see [[CI Quality Gate]] |
+| Hosts are healthy | Prometheus targets up, no firing alerts |
+| Storage is policy-compliant | Nothing violates the storage policy |
+
+> [!fail] Not goals
+> "Improve the Ansible roles." "Clean up Terraform." "Harden the hosts."
+> No failure condition means the agent cannot tell when to stop.
+
+### The archive is load-bearing
+
+An agent picks up work from written state, not from a meeting. If it is not written down,
+the agent re-derives it, guesses it, or rediscovers an incident the hard way.
+
+- `git log` — what changed, when, and why
+- `docs/` — architecture, storage policy, SSH key policy, storage decisions
+- `docs/operations/` — the supported procedures; if it is not written there, it is not supported
+- `ansible/playbooks/host-audit.yml` — read-only host reality, on demand
+- `terraform plan` — the gap between declared and actual infrastructure
+
+The last two matter most: they are the only way to learn the *current* state without changing
+it. Both are read-only by construction and must stay that way.
+
+> [!important] Rule
+> Any incident, workaround, or manual fix lands in `docs/` in the same change that fixes it.
+> An undocumented fix is invisible to the next agent, which means it will be undone.
+
+## The rest cycle
+
+A scheduled run that may look and report, but not change:
+
+- `ansible-playbook … --check --diff` → configuration drift
+- `terraform plan` → infrastructure drift
+- `host-audit.yml` → hardware, storage, and version reality
+- Monitoring targets and firing alerts
+
+Output is a report or an issue, never a change. Drift found this way is the most valuable
+thing the environment produces: it is the difference between what the repository claims and
+what the hardware is actually doing, and nobody notices it during normal work.
+
+## Where the analogy breaks
+
+> [!danger] Infrastructure is not mathematics
+> The experiment this model comes from ran in maths, where a wrong result costs nothing — the
+> reviewer rejects it and the agent moves on. A wrong `terraform apply` destroys a disk. A wrong
+> `authorized_keys` locks out every administrator. There is no reviewer that catches it after
+> the fact.
+
+So the model is adopted asymmetrically, deliberately:
+
+- **Exploration is unbounded** in the read and plan plane.
+- **The write plane stays narrow and human-gated**, exactly where the storage policy already
+  says the expensive mistakes live.
+
+Autonomy is granted where mistakes are cheap and reversible, and not where they are not.
+See [[Rights Not Prompts]].
+
+## Related
+
+- [[Rights Not Prompts]]
+- [[Agent Permission Matrix]]
+- [[Plan-Only Proxmox Token]]
+- [[CI Quality Gate]]
+- [[Agent Environment Gaps]]

--- a/docs/obsidian/Agent Permission Matrix.md
+++ b/docs/obsidian/Agent Permission Matrix.md
@@ -1,0 +1,42 @@
+---
+title: Agent Permission Matrix
+aliases:
+  - Õiguste maatriks
+tags:
+  - reference
+  - security
+  - ai-agents
+  - proxmox
+repo: insippo/proxmox-infra
+source: docs/agent-environment.md
+up: "[[Agent Environment]]"
+---
+
+# Agent Permission Matrix
+
+What an automated identity may do, and — the part that matters — what enforces each answer.
+
+| Action | Agent | Enforced by |
+|---|---|---|
+| Read the repository, run linters | ✅ | No credential needed |
+| `ansible-playbook --check --diff` | ✅ | Read-only Ansible user |
+| `ansible/playbooks/host-audit.yml` | ✅ | Read-only by construction |
+| `terraform plan` | ✅ | [[Plan-Only Proxmox Token]] |
+| Open a branch and a pull request | ✅ | Repository write, no merge |
+| Merge to `master` | ❌ | Branch protection + required CI |
+| `terraform apply` (create/update) | ❌ | Token lacking `VM.Allocate` / `Datastore.Allocate` |
+| `terraform destroy`, any VM deletion | ❌ | Token lacking `VM.Allocate`; `prevent_destroy` |
+| Ansible apply run (no `--check`) | ❌ | Read-only SSH user, no sudo |
+| Storage configuration changes | ❌ | Not reachable by the token; policy review required |
+| `ssh_keys_enforce: true` | ❌ | Human, with console access open |
+| API token creation or rotation | ❌ | Human, Proxmox UI |
+
+> [!important] Read the right-hand column
+> Every ❌ is a credential the agent does not hold, not an instruction it was asked to follow.
+> See [[Rights Not Prompts]].
+
+## Related
+
+- [[Agent Environment]]
+- [[Rights Not Prompts]]
+- [[Plan-Only Proxmox Token]]

--- a/docs/obsidian/CI Quality Gate.md
+++ b/docs/obsidian/CI Quality Gate.md
@@ -12,7 +12,7 @@ repo: insippo/proxmox-infra
 source: docs/agent-environment.md
 workflow: .github/workflows/ci.yml
 up: "[[Agent Environment]]"
-status: failing
+status: fixed-pending-merge
 ---
 
 # CI Quality Gate
@@ -26,16 +26,16 @@ Defined in `.github/workflows/ci.yml`: `ansible-lint`, `terraform fmt -check`,
 > [!note] The reviewer is a machine, not the agent's own judgement.
 > An agent may not merge on the grounds that it believes the work is correct.
 
-## Current state: broken since inception
+## Was broken since inception — now fixed, pending merge
 
-> [!bug] `Ansible Lint` has failed on every run of the quality gate
+> [!bug] `Ansible Lint` failed on every run of the quality gate
 > All 19 runs on `master`, from run #1 (`Add basic CI quality gate for Ansible and Terraform`)
-> onward. The `terraform fmt` and `terraform validate` jobs pass.
+> onward. The `terraform fmt` and `terraform validate` jobs always passed.
 
 A gate that rejects everything gates nothing. It cannot distinguish a good change from a bad one,
-so nobody can use it as a merge condition, and in practice it is ignored.
+so nobody can use it as a merge condition, and in practice it was ignored.
 
-### Known causes
+### Causes
 
 1. **Roles cannot be resolved.** `roles_path` is not configured, so `ansible-lint` looks under
    `ansible/playbooks/roles` and never finds `ansible/roles/`.
@@ -48,18 +48,26 @@ so nobody can use it as a merge condition, and in practice it is ignored.
    `var-naming[no-role-prefix]`, `no-handler`, `command-instead-of-module`, plus
    `yaml[trailing-spaces]` and `yaml[empty-lines]`.
 
-### Proposed fix
+### The fix
 
-- [ ] Add `ansible/ansible.cfg` with `roles_path = roles`
-- [ ] Add `ansible-galaxy collection install ansible.posix` to the lint job, ideally via a
-      committed `requirements.yml` so local runs match CI
-- [ ] Decide explicitly on the profile: fix the findings, or drop to `profile: moderate` and
-      re-add rules as the roles are cleaned up
-- [ ] Fix trailing whitespace and blank lines regardless — mechanical, no judgement needed
+- [x] `ansible.cfg` at the repository root with `roles_path = ansible/roles`
+- [x] `ansible/requirements.yml` declaring `ansible.posix` and `community.general`, installed
+      by the lint job so local runs match CI
+- [x] `production` profile findings resolved: `--fix` formatting, the role-prefix rename, and
+      two deviations annotated with `noqa` and a stated reason rather than silently relaxed
+- [x] `ansible.builtin.timezone` → `community.general.timezone` — it is not in ansible-core and
+      would have failed at runtime, not only in the linter
 
-> [!warning] This blocks everything else
+Verified: `Profile 'production' was required, and it passed`, 0 failures. All three playbooks
+now pass `--syntax-check`; none did before.
+
+> [!warning] Still blocks everything else until merged
 > Until the gate is green on `master`, "CI is green" is not a usable metric and no automated
 > identity should be granted anything beyond read access.
+
+> [!tip] Worth adding
+> The lint job installs `ansible-lint` unpinned. A future release adding rules can turn the gate
+> red again with no change to this repository. Pinning it removes that failure mode.
 
 ## Related
 

--- a/docs/obsidian/CI Quality Gate.md
+++ b/docs/obsidian/CI Quality Gate.md
@@ -1,0 +1,67 @@
+---
+title: CI Quality Gate
+aliases:
+  - The reviewer
+  - Ansible Lint failure
+tags:
+  - ci
+  - status
+  - proxmox
+  - blocker
+repo: insippo/proxmox-infra
+source: docs/agent-environment.md
+workflow: .github/workflows/ci.yml
+up: "[[Agent Environment]]"
+status: failing
+---
+
+# CI Quality Gate
+
+The reviewer in the [[Agent Environment]] model. Without one, an environment-driven agent
+optimises for volume.
+
+Defined in `.github/workflows/ci.yml`: `ansible-lint`, `terraform fmt -check`,
+`terraform validate`. Runs on every push and pull request. Deploys nothing.
+
+> [!note] The reviewer is a machine, not the agent's own judgement.
+> An agent may not merge on the grounds that it believes the work is correct.
+
+## Current state: broken since inception
+
+> [!bug] `Ansible Lint` has failed on every run of the quality gate
+> All 19 runs on `master`, from run #1 (`Add basic CI quality gate for Ansible and Terraform`)
+> onward. The `terraform fmt` and `terraform validate` jobs pass.
+
+A gate that rejects everything gates nothing. It cannot distinguish a good change from a bad one,
+so nobody can use it as a merge condition, and in practice it is ignored.
+
+### Known causes
+
+1. **Roles cannot be resolved.** `roles_path` is not configured, so `ansible-lint` looks under
+   `ansible/playbooks/roles` and never finds `ansible/roles/`.
+   - `syntax-check[specific]: the role 'ssh_keys' was not found` — `ansible/playbooks/proxmox-host.yml:29`
+   - `syntax-check[specific]: the role 'docker' was not found` — `ansible/playbooks/vm-base.yml:15`
+2. **Missing collection.** `ansible.posix` is not installed in the CI job, so
+   `ansible.posix.authorized_key` does not resolve — `roles/admin_user/tasks/main.yml:24`,
+   `roles/ssh_keys/tasks/main.yml:20`.
+3. **`profile: production`** in `.ansible-lint` enforces rules the roles do not satisfy:
+   `var-naming[no-role-prefix]`, `no-handler`, `command-instead-of-module`, plus
+   `yaml[trailing-spaces]` and `yaml[empty-lines]`.
+
+### Proposed fix
+
+- [ ] Add `ansible/ansible.cfg` with `roles_path = roles`
+- [ ] Add `ansible-galaxy collection install ansible.posix` to the lint job, ideally via a
+      committed `requirements.yml` so local runs match CI
+- [ ] Decide explicitly on the profile: fix the findings, or drop to `profile: moderate` and
+      re-add rules as the roles are cleaned up
+- [ ] Fix trailing whitespace and blank lines regardless — mechanical, no judgement needed
+
+> [!warning] This blocks everything else
+> Until the gate is green on `master`, "CI is green" is not a usable metric and no automated
+> identity should be granted anything beyond read access.
+
+## Related
+
+- [[Agent Environment]]
+- [[Agent Environment Gaps]]

--- a/docs/obsidian/Plan-Only Proxmox Token.md
+++ b/docs/obsidian/Plan-Only Proxmox Token.md
@@ -1,0 +1,56 @@
+---
+title: Plan-Only Proxmox Token
+aliases:
+  - Agent token
+  - terraform-planner role
+tags:
+  - howto
+  - proxmox
+  - security
+  - ai-agents
+repo: insippo/proxmox-infra
+source: docs/agent-environment.md
+up: "[[Agent Environment]]"
+---
+
+# Plan-Only Proxmox Token
+
+The repository's `docs/terraform-proxmox-api-token.md` describes **one** token holding the full
+write set: `VM.Allocate`, `VM.Clone`, `VM.Config.*`, `VM.PowerMgmt`, `Datastore.Allocate`,
+`Datastore.AllocateSpace`.
+
+That token is correct for an operator running `terraform apply`.
+
+> [!danger] It must never be the token an agent holds.
+
+## The second token
+
+Create a separate token for agent and CI use:
+
+- **User:** a dedicated `agent@pve` — not `root@pam`, not the Terraform user
+- **Privilege separation:** enabled
+- **Role:** custom, e.g. `terraform-planner`, holding only:
+  - `VM.Audit`
+  - `Datastore.Audit`
+  - `Sys.Audit`
+- **Path:** scope the ACL to the VM pool in use, not to `/`
+- **Expiration:** set one — a non-expiring agent token is a permanent liability
+
+This is enough for `terraform plan` and for reading state. It cannot create, clone, reconfigure,
+power-cycle, or delete anything.
+
+> [!info] When an apply is needed
+> If an agent's plan requires an apply, a human runs the apply with the operator token. That is
+> the gate, and it is the point.
+
+## Verify which token you are holding
+
+```bash
+./scripts/check-proxmox-token-permissions.sh
+```
+
+## Related
+
+- [[Rights Not Prompts]]
+- [[Agent Permission Matrix]]
+- [[Agent Environment Gaps]]

--- a/docs/obsidian/README.md
+++ b/docs/obsidian/README.md
@@ -1,0 +1,18 @@
+# Obsidian vault copy
+
+Obsidian-formatted notes mirroring `docs/agent-environment.md`: YAML frontmatter, wiki-style internal links,
+callouts, and task checkboxes that Obsidian's Tasks and Dataview plugins can query.
+
+**To use:** copy this folder into your vault, or open `docs/` in Obsidian as a vault.
+
+**Canonical source is the repository.** When these notes and `docs/agent-environment.md` disagree,
+the repository document wins. Update it first, then reflect the change here.
+
+Notes:
+
+- `Agent Environment.md` — map of content, start here
+- `Rights Not Prompts.md` — the core principle and the blast radius
+- `Agent Permission Matrix.md` — what an agent may do and what enforces each answer
+- `Plan-Only Proxmox Token.md` — the credential split, concretely
+- `CI Quality Gate.md` — the reviewer, and why it does not currently work
+- `Agent Environment Gaps.md` — what must be built before unattended access

--- a/docs/obsidian/Rights Not Prompts.md
+++ b/docs/obsidian/Rights Not Prompts.md
@@ -1,0 +1,89 @@
+---
+title: Rights Not Prompts
+aliases:
+  - Piirid on õigustes
+  - Boundaries in permissions
+tags:
+  - principle
+  - security
+  - ai-agents
+  - proxmox
+repo: insippo/proxmox-infra
+source: docs/agent-environment.md
+up: "[[Agent Environment]]"
+---
+
+# Rights Not Prompts
+
+> [!quote] The principle
+> An instruction is not a control. A missing credential is.
+
+A prompt is a suggestion the model may reinterpret. It is not a boundary. The only boundary
+that holds under an agent that works in parallel, does not ask, and reads whatever it is
+allowed to read is **what the credentials permit**.
+
+So every "no" in [[Agent Permission Matrix]] is a credential that does not exist for the agent,
+not a rule it was asked to follow.
+
+## Blast radius
+
+Damage is not evenly spread. Three areas cause real, expensive loss:
+
+> [!danger] Storage changes
+> Governed by the repository's storage policy, which exists because of a production incident.
+> Storage decisions are hard to reverse.
+
+> [!danger] VM destruction
+> `terraform apply` can destroy a VM and its disk in one step.
+
+> [!danger] SSH key enforcement
+> `ssh_keys_enforce: true` rewrites `authorized_keys`. On a Proxmox cluster that is the shared
+> `/etc/pve/priv/authorized_keys`. A wrong key list locks every administrator out of every node.
+
+Everything else — linting, docs, monitoring dashboards, role refactors — is cheap to get wrong
+and cheap to revert.
+
+That asymmetry is the whole design input:
+
+> [!tip] The rule that falls out of it
+> The read and plan plane stays wide open. The write plane stays narrow.
+
+## How each boundary is drawn
+
+### Proxmox API
+
+Two tokens, never one. The operator token holds the full write set; the agent holds an
+audit-only token that cannot create, clone, reconfigure, power-cycle, or delete anything.
+See [[Plan-Only Proxmox Token]].
+
+### SSH
+
+The agent connects as an unprivileged user with **no** `sudo` rights — enough for `--check` runs
+and fact gathering. `root` on Proxmox hosts stays with humans and console recovery.
+
+`ssh_keys_enforce` stays `false` for every agent-reachable path. Enforcement is a human action,
+performed with a console session already open.
+
+> [!success] Why this is sufficient
+> An agent that cannot become root cannot lock anyone out, regardless of what it decides to do.
+
+### Terraform
+
+`prevent_destroy = true` on every VM that holds state or that something depends on. It is not a
+substitute for token scoping — an agent with an apply token could remove the guard and then
+apply — but combined with an audit-only token it makes destruction unreachable from two
+directions.
+
+### Secrets
+
+`terraform.tfvars`, `ansible/inventory.yml`, and token secrets are not committed and must not be
+readable by an agent that opens pull requests. An agent's run environment carries the plan token
+and nothing else.
+
+> [!warning] Anything an agent can read, it can inadvertently write into a diff or a PR description.
+
+## Related
+
+- [[Agent Environment]]
+- [[Agent Permission Matrix]]
+- [[Plan-Only Proxmox Token]]


### PR DESCRIPTION
## What

Adds `docs/agent-environment.md` and links it from `README.md`, with an Obsidian-formatted copy of the same material under `docs/obsidian/`.

The document defines how an automated identity — CI, a scheduled script, or an AI agent — may operate against this infrastructure, and how each boundary is actually enforced rather than merely instructed.

It also carries the Ansible Lint fix from #5 (see **Scope** below).

## Why

The repository is written for a human executor working in sequence. An automated one works in parallel, does not ask, and reads whatever it is permitted to read. A prompt is a suggestion; a missing credential is a control. Documenting that distinction before granting any unattended access is cheaper than discovering it afterwards, particularly given the incident already recorded in `docs/storage-policy.md`.

## Contents

- **Four parts of an agent environment** — goal/metric, archive, mailbox, reviewer — mapped onto parts of this repo that already exist: `ansible/playbooks/host-audit.yml`, `terraform plan`, `docs/operations/`, pull requests, and the CI quality gate.
- **Permission matrix** — every "No" is backed by a credential the automated identity does not hold, not by a rule it is asked to follow.
- **Plan-only Proxmox token** — a dedicated user with a custom `VM.Audit` / `Datastore.Audit` / `Sys.Audit` role, privilege separation on, ACL scoped to the VM pool, expiration set. Kept separate from the full-write operator token described in `docs/terraform-proxmox-api-token.md`, which stays unchanged.
- **Unprivileged SSH path** — sudo-less user for `--check` runs; root reserved for humans and console recovery; `ssh_keys_enforce` stays a human action per the existing rotation procedure.
- **Scheduled read-only drift runs** — `--check --diff`, `terraform plan`, host audit; output is a report, never a change.
- **Where the analogy breaks** — exploration is unbounded in the read/plan plane; the write plane stays narrow, because a wrong apply or a wrong `authorized_keys` has no after-the-fact reviewer.
- **Gap list** — plan-only token, branch protection, `CODEOWNERS`, a policy check job in CI, a scheduled drift run, and a read-only Ansible user. These are open items, not claims about current state.
- **Obsidian copy** — the same material split into six linked notes with frontmatter, callouts and task checkboxes, in `docs/obsidian/`. The repository document stays canonical.

## Scope

Documentation, **plus one ported commit**: `9ec0771` from #5, cherry-picked here so this PR's CI can pass. It adds `ansible.cfg` (`roles_path`), `ansible/requirements.yml`, the collection-install step in the lint job, and the `production` profile fixes; it also corrects `ansible.builtin.timezone` to `community.general.timezone`, which is not in ansible-core and would have failed at runtime, not only in the linter.

That commit is not this PR's own work and no-ops once #5 reaches `master`. Merging #5 first is the tidier order; this PR does not depend on it.

Nothing here alters what current credentials can do — the document describes the split that should exist before agent access is granted.

## Verification

All three checks pass on the current head. Locally, `ansible-lint ansible/` reports `Profile 'production' was required, and it passed` with 0 failures, and all three playbooks pass `--syntax-check` — none did before the ported fix, because roles could not be resolved.